### PR TITLE
Fixed an issue with Click and Tempo

### DIFF
--- a/src/heronarts/lx/Tempo.java
+++ b/src/heronarts/lx/Tempo.java
@@ -60,6 +60,7 @@ public class Tempo extends LXComponent {
   private int tapCount = 0;
 
   private int beatCount = 0;
+  private boolean triggered = false;
 
   public Tempo(LX lx) {
     super(lx);
@@ -176,6 +177,7 @@ public class Tempo extends LXComponent {
   public void trigger() {
     this.beatCount = 0;
     this.click.fire();
+    this.triggered = true;
   }
 
   /**
@@ -203,8 +205,9 @@ public class Tempo extends LXComponent {
   @Override
   public void loop(double deltaMs) {
     super.loop(deltaMs);
-    if (beat()) {
+    if (beat() && !triggered) {
       ++this.beatCount;
     }
+    this.triggered = false;
   }
 }

--- a/src/heronarts/lx/modulator/Click.java
+++ b/src/heronarts/lx/modulator/Click.java
@@ -27,8 +27,6 @@ import heronarts.lx.parameter.LXParameter;
  */
 public class Click extends LXPeriodicModulator {
 
-  private double elapsedMs = 0;
-
   public Click(double periodMs) {
     this(new FixedParameter(periodMs));
   }
@@ -52,7 +50,6 @@ public class Click extends LXPeriodicModulator {
    */
   public Click stopAndReset() {
     this.stop();
-    this.elapsedMs = 0;
     this.setBasis(0);
     return this;
   }
@@ -65,7 +62,6 @@ public class Click extends LXPeriodicModulator {
    * @return this
    */
   public LXModulator fire() {
-    this.elapsedMs = 0;
     setValue(1);
     start();
     return this;
@@ -89,13 +85,7 @@ public class Click extends LXPeriodicModulator {
 
   @Override
   protected double computeValue(double deltaMs, double basis) {
-    double periodMs = getPeriod();
-    this.elapsedMs += deltaMs;
-    if (this.elapsedMs >= periodMs) {
-      this.elapsedMs = this.elapsedMs % periodMs;
-      return 1;
-    }
-    return 0;
+    return loop() || finished() ? 1 : 0;
   }
 
   @Override


### PR DESCRIPTION
Fixed issue where Click wouldn't be internally consistent between click() and getBasis() when the internal period parameter was changed dynamically. This caused issues where the Tempo ramp() wouldn't be consistent with beat() when you changed the bpm.

Additionally, fixed an issue where Tempo wouldn't fire beat() on the same frame as a trigger(), leading to beat() being conceptually called at the end of the beat instead of the beginning.

The triggered variable is to allow the beatCount to be correct both between trigger() and computeValue() are called and after computeValue() is called. If that's not a requirement, beatCount could just be set to -1 on trigger().