### PR TITLE
Optimize away modulus in hsb function

### DIFF
--- a/src/heronarts/lx/color/LXColor.java
+++ b/src/heronarts/lx/color/LXColor.java
@@ -181,7 +181,7 @@ public class LXColor {
    * @return rgb color value
    */
   public static int hsb(float h, float s, float b) {
-    return Color.HSBtoRGB((h % 360) / 360.f, s / 100.f, b / 100.f);
+    return Color.HSBtoRGB(h / 360.f - (int)h / 360, s / 100.f, b / 100.f);
   }
 
   /**


### PR DESCRIPTION
In my testing, it was faster to use an integer division and floating point subtraction than to use a floating point modulus. I will mention though that Java JIT compiler optimizations still have plenty of black-boxiness to them, so I can’t be certain that it’s more efficient in all circumstances, just the ones I tested.