### PR TITLE
Adding a logarithmic/exponent formatter for parameters

### DIFF
--- a/src/heronarts/lx/parameter/LXParameter.java
+++ b/src/heronarts/lx/parameter/LXParameter.java
@@ -48,7 +48,8 @@ public interface LXParameter {
     SECONDS,
     MILLISECONDS,
     DECIBELS,
-    HERTZ;
+    HERTZ,
+    LOG10;
 
     public String format(double value) {
       return Units.format(this, value);
@@ -88,6 +89,8 @@ public interface LXParameter {
         return String.format("%.2fHz", value);
       case DECIBELS:
         return String.format("%.1fdB", value);
+      case LOG10:
+        return String.format("%.2f", Math.pow(10, value));
       default:
       case NONE:
         return String.format("%.2f", value);


### PR DESCRIPTION
When a parameter range spans orders of magnitude (eg from 0.01 to 10), the parameter is often thought of logarithmically.  However, since parameter knobs are linear, pretty much all the control is just in the top order of magnitude (ie from 1 to 10).

A common solution is to do a log10 transform on the underlying values.  ie the value of the parameter isn't 0.01 or 10, rather it is `Math.log10(0.01) = -2` or `Math.log10(10) = 2`. 

With this, you have a parameter range of -2 to 2, which gives you an even sweep across your orders of magnitude with your linear parameter knobs.

This kinda stuff comes up a lot when you're dealing with ratios or sound stuff.

Reading that kind of representation is hard, though.  Proposed solution here is to provide a logarithmic formatter -- if your underlying quantity is a log exponent, this puts it back into decimal form.

------

I think a better solution would be instead of providing a `Units` enum that has formatting logic built in, just define a `Formatter` interface.  The provided `Units` enums can implement the interface and are neat tools to solve common formattings, but the main point is since the idea of a Formatter is just an interface, it would allow custom user formatters to be created and used without hacking the core lib (enums in java can't be subclassed).  But doing that would also require some breaking changes in p3lx.