### PR TITLE
Making VariableLFO more extendable

### DIFF
--- a/src/heronarts/lx/modulator/LXWaveshape.java
+++ b/src/heronarts/lx/modulator/LXWaveshape.java
@@ -45,6 +45,11 @@ public interface LXWaveshape {
       }
       return (angle + LX.HALF_PI) / LX.TWO_PI;
     }
+
+    @Override
+    public String toString() {
+      return "SIN";
+    }
   };
 
   public static LXWaveshape TRI = new LXWaveshape() {
@@ -56,6 +61,11 @@ public interface LXWaveshape {
     @Override
     public double invert(double value, double basisHint) {
       return (basisHint < 0.5) ? (value / 2.) : (1. - (value / 2.));
+    }
+
+    @Override
+    public String toString() {
+      return "TRI";
     }
   };
 
@@ -70,6 +80,11 @@ public interface LXWaveshape {
     public double invert(double value, double basisHint) {
       return value;
     }
+
+    @Override
+    public String toString() {
+      return "UP";
+    }
   };
 
   public static LXWaveshape DOWN = new LXWaveshape() {
@@ -83,6 +98,11 @@ public interface LXWaveshape {
     public double invert(double value, double basisHint) {
       return 1. - value;
     }
+
+    @Override
+    public String toString() {
+      return "DOWN";
+    }
   };
 
   public static LXWaveshape SQUARE = new LXWaveshape() {
@@ -95,6 +115,11 @@ public interface LXWaveshape {
     @Override
     public double invert(double value, double basisHint) {
       return (value == 0) ? 0 : 0.5;
+    }
+
+    @Override
+    public String toString() {
+      return "SQUARE";
     }
   };
 

--- a/src/heronarts/lx/modulator/VariableLFO.java
+++ b/src/heronarts/lx/modulator/VariableLFO.java
@@ -20,7 +20,10 @@
 
 package heronarts.lx.modulator;
 
-import heronarts.lx.parameter.*;
+import heronarts.lx.parameter.CompoundParameter;
+import heronarts.lx.parameter.DiscreteParameter;
+import heronarts.lx.parameter.FixedParameter;
+import heronarts.lx.parameter.LXParameter;
 
 /**
  * A sawtooth LFO oscillates from one extreme value to another. When the later

--- a/src/heronarts/lx/modulator/VariableLFO.java
+++ b/src/heronarts/lx/modulator/VariableLFO.java
@@ -20,10 +20,7 @@
 
 package heronarts.lx.modulator;
 
-import heronarts.lx.parameter.CompoundParameter;
-import heronarts.lx.parameter.EnumParameter;
-import heronarts.lx.parameter.FixedParameter;
-import heronarts.lx.parameter.LXParameter;
+import heronarts.lx.parameter.*;
 
 /**
  * A sawtooth LFO oscillates from one extreme value to another. When the later
@@ -31,23 +28,14 @@ import heronarts.lx.parameter.LXParameter;
  */
 public class VariableLFO extends LXRangeModulator implements LXWaveshape {
 
-  public enum Waveshape {
-    SIN,
-    TRI,
-    SQUARE,
-    UP,
-    DOWN
-  };
+  /**
+   * Parameter of {@link LXWaveshape} objects that select the wave shape used by this LFO.
+   * Default options are the waveshapes predefined in {@link LXWaveshape}, but you can pass your own.
+   */
+  public final DiscreteParameter waveshape;
 
-  public final EnumParameter<Waveshape> waveshape =
-    new EnumParameter<Waveshape>("Wave", Waveshape.SIN)
-    .setDescription("Selects the wave shape used by this LFO");
-
-  public final CompoundParameter period = (CompoundParameter)
-    new CompoundParameter("Period", 1000, 100, 10000)
-    .setDescription("Sets the period of the LFO in secs")
-    .setExponent(2)
-    .setUnits(LXParameter.Units.MILLISECONDS);
+  /** Period of the waveform, in ms */
+  public final CompoundParameter period;
 
   public final CompoundParameter skew = (CompoundParameter)
     new CompoundParameter("Skew", 0, -1, 1)
@@ -69,11 +57,49 @@ public class VariableLFO extends LXRangeModulator implements LXWaveshape {
     .setDescription("Shifts the phase of the waveform");
 
   public VariableLFO() {
-    this("LFO");
+    this("LFO", null, null);
   }
 
   public VariableLFO(String label) {
+    this(label, null, null);
+  }
+
+  public VariableLFO(String label, LXWaveshape[] waveshapes) {
+    this(label, waveshapes, null);
+  }
+
+  /**
+   * Constructs a VariableLFO with a custom list of waveshapes
+   * @param label LFO label
+   * @param waveshapes Optional list of custom {@link LXWaveshape}.  If null, will use predefined ones
+   *                   in {@link LXWaveshape}
+   * @param period Optional. Parameter that supplies custom waveform period, in ms.  Default goes 100-10000ms.
+   */
+  public VariableLFO(String label, LXWaveshape[] waveshapes, CompoundParameter period) {
     super(label, new FixedParameter(0), new FixedParameter(1), new FixedParameter(1000));
+
+    if (waveshapes == null) {
+      waveshapes = new LXWaveshape[] {
+          LXWaveshape.SIN,
+          LXWaveshape.TRI,
+          LXWaveshape.SQUARE,
+          LXWaveshape.UP,
+          LXWaveshape.DOWN
+      };
+    }
+
+    this.waveshape = new DiscreteParameter("Wave", waveshapes);
+    this.waveshape.setDescription("Selects the wave shape used by this LFO");
+
+    if (period == null) {
+      period = (CompoundParameter) new CompoundParameter("Period", 1000, 100, 10000)
+        .setDescription("Sets the period of the LFO in secs")
+        .setExponent(2)
+        .setUnits(LXParameter.Units.MILLISECONDS);
+    }
+    this.period = period;
+
+
     setPeriod(period);
     addParameter("wave", waveshape);
     addParameter("period", period);
@@ -84,14 +110,7 @@ public class VariableLFO extends LXRangeModulator implements LXWaveshape {
   }
 
   public LXWaveshape getWaveshape() {
-    switch (this.waveshape.getEnum()) {
-    case SIN: return LXWaveshape.SIN;
-    case TRI: return LXWaveshape.TRI;
-    case UP: return LXWaveshape.UP;
-    case DOWN: return LXWaveshape.DOWN;
-    case SQUARE: return LXWaveshape.SQUARE;
-    }
-    return LXWaveshape.SIN;
+    return (LXWaveshape) this.waveshape.getObject();
   }
 
   @Override


### PR DESCRIPTION
`VariableLFO` is a neat little set of parameters around a waveshape.  It's also the only modulator that has a UI out-of-the-box in P3LX.  However, the way it is built you can't really extend it with your own components.

This PR addresses two limitations I encountered:
1. Can't use custom `LXWaveshape`
2. Stuck with the default `period` param (can't change timing range if it's not quite what you want)

With this PR, you can do, for example:

```java
new VariableLFO("LFO with custom waveshapes", new LXWaveshape[] {
  new LXWaveshape() {
    public String toString() { return "EXP_OUT"; }

    @Override
    public double compute(double basis) {
      // https://github.com/d3/d3-ease#easeExpOut
      return 1 - Math.pow(2, -10 * basis);
    }

    // ... and invert()
  },

  new LXWaveshape() {
    public String toString() { return "BOUNCE_IN"; }

    @Override
    public double compute(double basis) {
      // Something really crazy like https://github.com/d3/d3-ease#easeBounceIn
      // see https://github.com/d3/d3-ease/blob/master/src/bounce.js#L12
    }
  }

  // or any other number of standard animation easings like CUBIC, QUAD, various IN_OUT combos, etc.
});