### PR TITLE
Adding support for momentary BooleanParameters in a trigger modulation

### DIFF
--- a/src/heronarts/lx/parameter/LXTriggerModulation.java
+++ b/src/heronarts/lx/parameter/LXTriggerModulation.java
@@ -47,10 +47,15 @@ public class LXTriggerModulation extends LXParameterModulation {
   @Override
   public void onParameterChanged(LXParameter p) {
     super.onParameterChanged(p);
-    if (p == this.source) {
-      if (this.source.isOn()) {
-        this.target.setValue(true);
-      }
+    if (p != this.source) {
+      return;
+    }
+
+    if (this.source.isOn()) {
+      this.target.setValue(true);
+
+    } else if (!this.source.isOn() && this.target.getMode() == BooleanParameter.Mode.MOMENTARY) {
+      this.target.setValue(false);
     }
   }
 

--- a/src/heronarts/lx/parameter/LXTriggerModulation.java
+++ b/src/heronarts/lx/parameter/LXTriggerModulation.java
@@ -47,15 +47,14 @@ public class LXTriggerModulation extends LXParameterModulation {
   @Override
   public void onParameterChanged(LXParameter p) {
     super.onParameterChanged(p);
-    if (p != this.source) {
-      return;
-    }
 
-    if (this.source.isOn()) {
-      this.target.setValue(true);
+    if (p == this.source) {
+      if (this.source.isOn()) {
+        this.target.setValue(true);
 
-    } else if (!this.source.isOn() && this.target.getMode() == BooleanParameter.Mode.MOMENTARY) {
-      this.target.setValue(false);
+      } else if (this.target.getMode() == BooleanParameter.Mode.MOMENTARY) {
+        this.target.setValue(false);
+      }
     }
   }
 


### PR DESCRIPTION
When a trigger modulation is applied, by default it only sets the target BooleanParameter high, it never sets it low.  

That's a fine interpretation in some scenarios, but when the target is set to `Mode.MOMENTARY`, it doesn't make much sense because the "momentary" BooleanParameter is set to high but never resets back to low.  Not very 'momentary'.

This PR proposes trigger modulation also set the BooleanParameter to low if it's configured as a momentary boolean.  

Useful in cases where the boolean param is exposed as a UISwitch. For example, when you have a momentary button to do something in your pattern, you might also want it to be a trigger target (https://github.com/heronarts/P3LX/pull/6). But it's inconsistent that clicking the momentary button acts like a momentary toggle, yet applying a trigger modulation leaves your "momentary" button stuck at high after the trigger hits.