### PR TITLE
Making sure patterns dispose of their modulation engine on disposal

### DIFF
--- a/src/heronarts/lx/LXDeviceComponent.java
+++ b/src/heronarts/lx/LXDeviceComponent.java
@@ -63,4 +63,10 @@ public abstract class LXDeviceComponent extends LXLayeredComponent implements LX
     }
   }
 
+  @Override
+  public void dispose() {
+    super.dispose();
+    this.modulation.dispose();
+  }
+
 }


### PR DESCRIPTION
On deserializing from json, I kept getting a few "Component id already in use" errors -- https://github.com/heronarts/LX/blob/ff98f6d546ea2c76508c6bbdaa944b15e9bc1062/src/heronarts/lx/LXComponent.java#L100

Some user modulators I added to my patterns weren't getting de-registered, so the registry had stale entries that caused conflicts on loading out of json.

Adding this `LXDeviceComponent#dispose()` override that calls `LXModulationEngine#dispose()` seems to do the right thing -- when a pattern gets disposed, it clears out its modulation engine as well.