### PR TITLE
Fixes example ant build script dependency and adds 'onDraw()' to start engine

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,9 +30,26 @@ Output via a variety of lighting protocols is supported, including:
 
 LX differs from many other lighting/VJ software packages in that it is designed to support non-uniform 3D pixel layouts, rather than dense 2D screens. Whereas many applications are capable of video mapping LED pixel arrays, LX functions more like a sparse vertex shader. The rendering engine takes into account the discrete spatial position of each pixel.
 
+### GUI interface
 A companion library, [P3LX](https://github.com/heronarts/P3LX), makes it simple to embed LX in the Processing 3 environment with modular UI controls and simulation, the  most typical use case. This core library is kept separate, free of any dependency on the Processing libraries or runtime.
 
 [LX Studio](https://github.com/heronarts/LXStudio) is a fully-featured digital lighting workstation with a rich UI for visualization and control.
+
+### Using this library headless
+LX may be used headless.
+
++ **Build the library:** navigate to `./build` directory and run `ant`  This will build the LX library into a jar `./bin/LX.jar`
++ **Build an example:** navigate to `./examples/LXHeadless/` and run `ant` this will build the example which links against the LX library we just built.
++ **Run it!**  On a bytecode capable machine run: `java -jar bin/LXHeadless.jar`
+
+By default the above example spews OPC formatted data via TCP on `localhost:7890`.
+This data can be viewed using the emulator that comes with [openpixelcontrol](https://github.com/zestyping/openpixelcontrol) as follows...
++ `git clone git://github.com/zestyping/openpixelcontrol.git`
++ `cd openpixelcontrol`
++ `make`
++ `bin/gl_server layouts/freespace.json`
+
+... you could also just use netcat to see raw data `nc -l 7890`
 
 ### Contact and Collaboration ###
 

--- a/examples/LXHeadless/build.xml
+++ b/examples/LXHeadless/build.xml
@@ -8,9 +8,14 @@
 			<classpath>
 				<pathelement location="../../lib/gson-2.8.0.jar"/>
 			</classpath>
+			<classpath>
+				<pathelement location="../../lib/coremidi4j-0.9.jar"/>
+			</classpath>
 			<compilerarg value="-Xlint"/>
 		</javac>
 		<jar jarfile="./bin/LXHeadless.jar" basedir="./bin">
+			<zipgroupfileset dir="../../lib" includes="coremidi4j-0.9.jar" />
+			<zipgroupfileset dir="../../lib" includes="gson-2.8.0.jar" />
 			<manifest>
 				<attribute name="Main-Class" value="heronarts.lx.headless.LXHeadless"/>
 			</manifest>

--- a/examples/LXHeadless/src/heronarts/lx/headless/LXHeadless.java
+++ b/examples/LXHeadless/src/heronarts/lx/headless/LXHeadless.java
@@ -19,11 +19,14 @@ package heronarts.lx.headless;
 
 import java.io.File;
 import heronarts.lx.LX;
+import heronarts.lx.LXPattern;
 import heronarts.lx.model.GridModel;
 import heronarts.lx.model.LXModel;
-import heronarts.lx.output.ArtNetDatagram;
-import heronarts.lx.output.FadecandyOutput;
-import heronarts.lx.output.LXDatagramOutput;
+import heronarts.lx.model.StripModel;
+import heronarts.lx.output.*;
+import heronarts.lx.pattern.*;
+
+import static java.lang.Thread.sleep;
 
 /**
  * Example headless CLI for the LX engine. Just write a bit of scaffolding code
@@ -33,7 +36,7 @@ public class LXHeadless {
 
   public static LXModel buildModel() {
     // TODO: implement code that loads and builds your model here
-    return new GridModel(10, 10);
+    return new GridModel(30, 30);
   }
 
   public static void addArtNetOutput(LX lx) throws Exception {
@@ -45,25 +48,65 @@ public class LXHeadless {
     );
   }
 
+//  public static void addOPCOutput(LX lx) throws Exception {
+//    lx.engine.addOutput(
+//            new OPCOutput(lx, "localhost", 7890).addDatagram(
+//                    new OPCDatagram(lx.model)
+//                            .setAddress("localhost")
+//            )
+//    );
+//  }
+
   public static void addFadeCandyOutput(LX lx) throws Exception {
     lx.engine.addOutput(new FadecandyOutput(lx, "localhost", 9090, lx.model));
   }
+
+
+//  private static void sleep(int millis) {
+//    try {
+//      Thread.sleep(millis);
+//    }
+//    catch (InterruptedException e) { /* pass */ };
+//  }
 
   public static void main(String[] args) {
     try {
       LXModel model = buildModel();
       LX lx = new LX(model);
 
-      // TODO: add your own output code here
-      // addArtNetOutput(lx);
-      // addFadecandyOutput(lx);
+//      LX lx = new LX(new StripModel(600));
+      String host = "localhost";
 
+      int port = 7890;
+      // TODO: add your own output code here
+//       addArtNetOutput(lx);
+//       addFadeCandyOutput(lx);
+      lx.engine.addOutput(new OPCOutput(lx, "localhost", 7890));
+//      lx.engine.addOutput(new UdpOPC(lx, host, port));
+//
       // On the CLI you specify an argument with an .lxp file
       if (args.length > 0) {
         lx.openProject(new File(args[0]));
       }
 
+      LXPattern[] patterns = new LXPattern[] {
+              new SimpleDemoPattern(lx)
+//              new BouncingPattern(lx)
+      };
+
+      lx.setPatterns(patterns);
+
+
+//      lx.registerPattern(new LXPattern[]{
+//               new BouncingPattern(lx)
+//      });
+//      System.out.println("starting threaded..");
+//      lx.engine.setThreaded(true);
+
       lx.engine.start();
+      lx.engine.onDraw();
+
+
     } catch (Exception x) {
       System.err.println(x.getLocalizedMessage());
     }

--- a/src/heronarts/lx/pattern/SimpleDemoPattern.java
+++ b/src/heronarts/lx/pattern/SimpleDemoPattern.java
@@ -1,0 +1,75 @@
+/**
+ * Copyright 2013- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package heronarts.lx.pattern;
+
+import heronarts.lx.LX;
+import heronarts.lx.LXPattern;
+import heronarts.lx.color.ColorParameter;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXPoint;
+import heronarts.lx.modulator.SinLFO;
+import heronarts.lx.modulator.TriangleLFO;
+import java.lang.*;
+
+public class SimpleDemoPattern extends LXPattern {
+
+  public final ColorParameter color = new ColorParameter("Color");
+  private final SinLFO sweepLFO = new SinLFO(model.xMin,  model.xMax, 4000);
+  private final SinLFO magLFO = new SinLFO(10, 100, 4000);
+
+
+  public SimpleDemoPattern(LX lx) {
+//    this(lx, LXColor.RED);
+    this(lx, LXColor.GREEN);
+  }
+
+  public SimpleDemoPattern(LX lx, int color) {
+    super(lx);
+    this.color.setColor(color);
+    addParameter("color", this.color);
+    setColors(this.color.getColor());
+
+    addModulator(this.magLFO).trigger();
+  }
+
+
+  double aggregateTime = 0;
+  @Override
+  public void run(double deltaMs) {
+    aggregateTime += deltaMs;
+
+//    float centerx = MathUtils.map(Noise.noise(centerParam, 100.0f), 0.0f, 1.0f, -0.1f, 1.1f);
+    setColors(LXColor.hsb(
+            (this.color.hue.getValue() + (aggregateTime/10))%360,
+            this.color.saturation.getValue(),
+            magLFO.getValue()
+//      this.color.brightness.getValue()
+    ));
+
+//    for (LXPoint p : model.points){
+//      inc++;
+//      colors[p.index] |=
+//      ((inc << inc));
+//      colors[p.index] |=
+//              (( (inc << (int)(bitmod*20) >> 5)) << 8);
+//      colors[p.index] |=
+//      ( (inc << (int)(bitmod*1.3) + 7)) << 16;
+//    }
+  }
+}


### PR DESCRIPTION
Fixes the Example ant build script dependency and adds 'lx.engine.onDraw()' which seems to be necessary to start the engine thread.  Finally gives instructions on how to actually run this thing headless.