### PR TITLE
Make LXBlend stateful.

### DIFF
--- a/src/heronarts/lx/LX.java
+++ b/src/heronarts/lx/LX.java
@@ -18,6 +18,15 @@
 
 package heronarts.lx;
 
+import heronarts.lx.blend.AddBlend;
+import heronarts.lx.blend.DarkestBlend;
+import heronarts.lx.blend.DifferenceBlend;
+import heronarts.lx.blend.DissolveBlend;
+import heronarts.lx.blend.LXBlend;
+import heronarts.lx.blend.LightestBlend;
+import heronarts.lx.blend.MultiplyBlend;
+import heronarts.lx.blend.NormalBlend;
+import heronarts.lx.blend.SubtractBlend;
 import heronarts.lx.clipboard.LXClipboard;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.color.LXPalette;
@@ -186,6 +195,35 @@ public class LX {
    */
   private final List<Class<? extends LXEffect>> registeredEffects =
     new ArrayList<Class<? extends LXEffect>>();
+
+  /**
+   * The list of globally registered channel blend classes
+   */
+  private static final List<Class<? extends LXBlend>> registeredChannelBlends =
+    new ArrayList<Class<? extends LXBlend>>();
+
+  /**
+   * The list of globally registered crossfader blend classes
+   */
+  private static final List<Class<? extends LXBlend>> registeredCrossfaderBlends =
+    new ArrayList<Class<? extends LXBlend>>();
+
+  static {
+    // Channel blend modes
+    LX.registerChannelBlend(AddBlend.class);
+    LX.registerChannelBlend(MultiplyBlend.class);
+    LX.registerChannelBlend(SubtractBlend.class);
+    LX.registerChannelBlend(DifferenceBlend.class);
+    LX.registerChannelBlend(NormalBlend.class);
+
+    // Crossfader blend modes
+    LX.registerCrossfaderBlend(DissolveBlend.class);
+    LX.registerCrossfaderBlend(AddBlend.class);
+    LX.registerCrossfaderBlend(MultiplyBlend.class);
+    LX.registerCrossfaderBlend(LightestBlend.class);
+    LX.registerCrossfaderBlend(DarkestBlend.class);
+    LX.registerCrossfaderBlend(DifferenceBlend.class);
+  }
 
   /**
    * Creates an LX instance with no nodes.
@@ -654,6 +692,103 @@ public class LX {
     return this.registeredEffects;
   }
 
+  /**
+   * Register a [channel and crossfader] blend class with the engine
+   *
+   * @param blend Blend class
+   */
+  public static void registerBlend(Class<? extends LXBlend> blend) {
+    registerChannelBlend(blend);
+    registerCrossfaderBlend(blend);
+  }
+
+  /**
+   * Register multiple [channel and crossfader] blend classes with the engine
+   *
+   * @param blends List of blend classes
+   */
+  public static void registerBlends(Class<LXBlend>[] blends) {
+    for (Class<LXBlend> blend : blends) {
+      registerChannelBlend(blend);
+      registerCrossfaderBlend(blend);
+    }
+  }
+
+  /**
+   * Register a channel blend class with the engine
+   *
+   * @param blend Blend class
+   */
+  public static void registerChannelBlend(Class<? extends LXBlend> blend) {
+    LX.registeredChannelBlends.add(blend);
+  }
+
+  /**
+   * Register multiple channel blend classes with the engine
+   *
+   * @param blends List of blend classes
+   */
+  public static void registerChannelBlends(Class<LXBlend>[] blends) {
+    for (Class<LXBlend> blend : blends) {
+      registerChannelBlend(blend);
+    }
+  }
+
+  /**
+   * Gets the list of registered channel blend classes
+   *
+   * @return Pattern classes
+   */
+  public List<Class<? extends LXBlend>> getRegisteredChannelBlends() {
+    return LX.registeredChannelBlends;
+  }
+
+  /**
+   * Register a crossfader blend class with the engine
+   *
+   * @param blend Blend class
+   */
+  public static void registerCrossfaderBlend(Class<? extends LXBlend> blend) {
+    LX.registeredCrossfaderBlends.add(blend);
+  }
+
+  /**
+   * Register multiple crossfader blend classes with the engine
+   *
+   * @param blends List of blend classes
+   * @return this
+   */
+  public static void registerCrossfaderBlends(Class<LXBlend>[] blends) {
+    for (Class<LXBlend> blend : blends) {
+      registerCrossfaderBlend(blend);
+    }
+  }
+
+  /**
+   * Gets the list of registered crossfader blend classes
+   *
+   * @return Pattern classes
+   */
+  public List<Class<? extends LXBlend>> getRegisteredCrossfaderBlends() {
+    return LX.registeredCrossfaderBlends;
+  }
+
+  public LXBlend[] getChannelBlendSet() {
+    ArrayList<LXBlend> blends = new ArrayList<LXBlend>();
+    for (Class<? extends LXBlend> blend : LX.registeredChannelBlends) {
+      blends.add(instantiateBlend(blend));
+    }
+    return blends.toArray(new LXBlend[0]);
+  }
+
+  public LXBlend[] getCrossfaderBlendSet() {
+    ArrayList<LXBlend> blends = new ArrayList<LXBlend>();
+    for (Class<? extends LXBlend> blend : LX.registeredCrossfaderBlends) {
+      blends.add(instantiateBlend(blend));
+    }
+    return blends.toArray(new LXBlend[0]);
+  }
+
   private final Map<String, LXSerializable> externals = new HashMap<String, LXSerializable>();
 
   private final static String KEY_VERSION = "version";
@@ -804,6 +939,14 @@ public class LX {
 
   protected LXEffect instantiateEffect(Class<? extends LXEffect> cls) {
     return instantiateComponent(cls, LXEffect.class);
+  }
+
+  protected LXBlend instantiateBlend(String className) {
+    return instantiateComponent(className, LXBlend.class);
+  }
+
+  protected LXBlend instantiateBlend(Class<? extends LXBlend> cls) {
+    return instantiateComponent(cls, LXBlend.class);
   }
 
 }

--- a/src/heronarts/lx/LXChannel.java
+++ b/src/heronarts/lx/LXChannel.java
@@ -211,7 +211,7 @@ public class LXChannel extends LXChannelBus {
       new DiscreteParameter("Focused Pattern", 0, patterns.length)
       .setDescription("Which pattern has focus in the UI");
 
-    this.transitionBlendMode = new ObjectParameter<LXBlend>("Transition Blend", lx.engine.crossfaderBlends)
+    this.transitionBlendMode = new ObjectParameter<LXBlend>("Transition Blend", lx.getCrossfaderBlendSet())
       .setDescription("Specifies the blending function used for transitions between patterns on the channel");
 
     this.transitionMillis = lx.engine.nowMillis;
@@ -607,7 +607,9 @@ public class LXChannel extends LXChannelBus {
       listener.patternWillChange(this, activePattern, nextPattern);
     }
     if (this.transitionEnabled.isOn()) {
-      this.transition = lx.engine.crossfaderBlends[this.transitionBlendMode.getValuei()];
+      //this.transition = lx.engine.crossfaderBlends[this.transitionBlendMode.getValuei()];
+      this.transition = this.transitionBlendMode.getObject();
+      this.transition.onActive();
       nextPattern.onTransitionStart();
       this.transitionMillis = this.lx.engine.nowMillis;
     } else {
@@ -621,6 +623,7 @@ public class LXChannel extends LXChannelBus {
     LXPattern activePattern = getActivePattern();
     if (this.transition != null) {
       activePattern.onTransitionEnd();
+      this.transition.onInactive();
     }
     this.transition = null;
     this.transitionMillis = this.lx.engine.nowMillis;

--- a/src/heronarts/lx/LXChannelBus.java
+++ b/src/heronarts/lx/LXChannelBus.java
@@ -110,6 +110,7 @@ public abstract class LXChannelBus extends LXBus implements LXComponent.Renamabl
     .setDescription("Sets the alpha level of the output of this channel");
 
   public final ObjectParameter<LXBlend> blendMode;
+  private LXBlend currentBlendMode;
 
   ChannelThread thread = new ChannelThread();
 
@@ -163,8 +164,10 @@ public abstract class LXChannelBus extends LXBus implements LXComponent.Renamabl
     this.blendBuffer = new ModelBuffer(lx);
     this.colors = this.blendBuffer.getArray();
 
-    this.blendMode = new ObjectParameter<LXBlend>("Blend", lx.engine.channelBlends)
+    this.blendMode = new ObjectParameter<LXBlend>("Blend", lx.getChannelBlendSet())
       .setDescription("Specifies the blending function used for the channel fader");
+    this.currentBlendMode = this.blendMode.getObject();
+    this.currentBlendMode.onActive();
 
     addParameter("enabled", this.enabled);
     addParameter("cue", this.cueActive);
@@ -185,6 +188,10 @@ public abstract class LXChannelBus extends LXBus implements LXComponent.Renamabl
         this.lx.engine.cueA.setValue(false);
         this.lx.engine.cueB.setValue(false);
       }
+    } else if (p == this.blendMode) {
+      currentBlendMode.onInactive();
+      currentBlendMode = this.blendMode.getObject();
+      currentBlendMode.onActive();
     }
   }
 

--- a/src/heronarts/lx/blend/LXBlend.java
+++ b/src/heronarts/lx/blend/LXBlend.java
@@ -124,4 +124,20 @@ public abstract class LXBlend extends LXModulatorComponent {
    * @param output Output buffer, which may be the same as src or dst
    */
   public abstract void blend(int[] dst, int[] src, double alpha, int[] output);
+
+  /**
+   * Subclasses may override this method. It will be invoked when the blend is
+   * about to become active. Blends may take care of any initialization needed
+   * or reset parameters if desired.
+   */
+  public/* abstract */void onActive() {
+  }
+
+  /**
+   * Subclasses may override this method. It will be invoked when the blend is
+   * no longer active. Resources may be freed if desired.
+   */
+  public/* abstract */void onInactive() {
+  }
+
 }


### PR DESCRIPTION
Adds onActive() and onInactive() methods to LXBlend, allowing blends to perform initialization and dispose of resources when complete.  Also creates unique instances of LXBlends for each ChannelBus fader, Channel transitions, and the master crossfader.  Adds methods for a project to register custom LXBlends with the engine.  Additional notes in email.