### PR TITLE
Enable asymmetrical blends.

### DIFF
--- a/src/heronarts/lx/LXChannel.java
+++ b/src/heronarts/lx/LXChannel.java
@@ -692,27 +692,14 @@ public class LXChannel extends LXChannelBus {
       this.autoCycleProgress = 1.;
       this.transitionProgress = (this.lx.engine.nowMillis - this.transitionMillis) / (1000 * this.transitionTimeSecs.getValue());
       getNextPattern().loop(deltaMs);
-      // TODO(mcslee): this is incorrect. the blend objects are shared, so the same one may be run on multiple
-      // channels. either they need to be per-channel instances, or they are not loopable with modulators etc.
       this.transition.loop(deltaMs);
       colors = this.blendBuffer.getArray();
-      if (this.transitionProgress < .5) {
-        double alpha = Math.min(1, this.transitionProgress*2.);
-        this.transition.blend(
-          getActivePattern().getColors(),
-          getNextPattern().getColors(),
-          alpha,
-          colors
-        );
-      } else {
-        double alpha = Math.max(0, (1-this.transitionProgress)*2.);
-        this.transition.blend(
-          getNextPattern().getColors(),
-          getActivePattern().getColors(),
-          alpha,
-          colors
-        );
-      }
+      this.transition.blendFullRange(
+        getActivePattern().getColors(),
+        getNextPattern().getColors(),
+        this.transitionProgress,
+        colors
+      );
     } else {
       this.transitionProgress = 0;
     }

--- a/src/heronarts/lx/LXEngine.java
+++ b/src/heronarts/lx/LXEngine.java
@@ -1199,6 +1199,12 @@ public class LXEngine extends LXComponent implements LXOscComponent, LXModulatio
       this.hasOutput = true;
     }
 
+    void blendFullRange(LXBlend blend, int[] src, double alphaFull) {
+      blend.blendFullRange(this.destination.getArray(), src, alphaFull, this.output.getArray());
+      this.destination = this.output;
+      this.hasOutput = true;
+    }
+
     void copyFrom(BlendStack that) {
       System.arraycopy(that.destination.getArray(), 0, this.output.getArray(), 0, that.destination.getArray().length);
       this.destination = this.output;
@@ -1427,15 +1433,9 @@ public class LXEngine extends LXComponent implements LXOscComponent, LXModulatio
 
     if (leftContent && rightContent) {
       // There are left and right channels assigned!
-      BlendStack crossfadeBlend;
       LXBlend blend = this.crossfaderBlendMode.getObject();
-      if (crossfadeValue <= 0.5) {
-        crossfadeBlend = blendStackLeft;
-        this.blendStackLeft.blend(blend, blendStackRight.destination.getArray(), Math.min(1, 2. * crossfadeValue));
-      } else {
-        crossfadeBlend = blendStackRight;
-        this.blendStackRight.blend(blend, blendStackLeft.destination.getArray(), Math.min(1, 2. * (1-crossfadeValue)));
-      }
+      BlendStack crossfadeBlend = blendStackLeft;
+      crossfadeBlend.blendFullRange(blend, blendStackRight.destination.getArray(), crossfadeValue);
       // Add the crossfaded groups to the main buffer
       this.blendStackMain.blend(this.addBlend, crossfadeBlend, 1.);
     } else if (leftContent) {

--- a/src/heronarts/lx/blend/LXBlend.java
+++ b/src/heronarts/lx/blend/LXBlend.java
@@ -126,6 +126,27 @@ public abstract class LXBlend extends LXModulatorComponent {
   public abstract void blend(int[] dst, int[] src, double alpha, int[] output);
 
   /**
+   * Blends the src buffer onto the destination buffer.
+   * With this method, alpha=.5 will be a 50/50 blend.
+   *
+   * Asymmetrical blends will want to override this method.
+   *
+   * @param dst Destination buffer (lower layer)
+   * @param src Source buffer (top layer)
+   * @param alpha Alpha blend, from 0-1
+   * @param output Output buffer, which may be the same as src or dst
+   */
+  public void blendFullRange(int[] dst, int[] src, double alphaFull, int[] output) {
+    if (alphaFull < .5) {
+      double alpha = Math.min(1, alphaFull*2.);
+      blend(dst, src, alpha, output);
+    } else {
+      double alpha = Math.max(0, (1-alphaFull)*2.);
+      blend(src, dst, alpha, output);
+    }
+  }
+
+  /**
    * Subclasses may override this method. It will be invoked when the blend is
    * about to become active for a transition. Blends may take care of any
    * initialization needed or reset parameters if desired. Note that a blend used on


### PR DESCRIPTION
It turns out that the existing method of calling blends for transitions and the master crossfader only work for symmetrical transitions.  For example, with a symmetrical blend such as AddBlend, it is perfectly fine to ramp alpha up from 0 to 1, switch the dst and src buffers, and then lower it from 1 to 0.

However, take for example an asymmetrical transition on our art car.  I have a transition which fades one gem (our crystal decorations) at a time.  The order in which the gems are transitioned is randomized and calculated in the onActive() method of the blend.  In this blend the second half is not an inverse of the first half.  While calling this frame is correct in the first half of the blend:
jouleBlend.blend(dst, src, .8, output)
Calling this frame is not correct in the second half of the blend:
jouleBlend.blend(src, dst, .8, output)

The blend really needs to know the actual transitionProgress.

This pull request is my attempt at fixing the problem with minimal disruption to other people and existing classes.  It does so by moving the transitionProgress->alpha calculation into the LXBlend class (from LXChannel transitions and also the master crossfader), so that asymmetrical LXBlends may override the method and use the full transitionProgress value.