### PR TITLE
Suppress switch fallthrough warning

### DIFF
--- a/src/heronarts/lx/parameter/LXParameter.java
+++ b/src/heronarts/lx/parameter/LXParameter.java
@@ -60,6 +60,7 @@ public interface LXParameter {
       return Units.format(this, value);
     }
 
+    @SuppressWarnings("fallthrough")
     public static String format(Units units, double value) {
       switch (units) {
       case INTEGER:


### PR DESCRIPTION
In doing a clean build, I encountered the following warning. The added annotation will suppress this warning.

```
compile:
    [mkdir] Created dir: /Users/philihp/work/LX/examples/LXHeadless/bin
    [javac] Compiling 211 source files to /Users/philihp/work/LX/examples/LXHeadless/bin
    [javac] /Users/philihp/work/LX/src/heronarts/lx/parameter/LXParameter.java:70: warning: [fallthrough] possible fall-through into case
    [javac]       case MILLISECONDS:
    [javac]       ^
    [javac] 1 warning
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/output/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/midi/remote/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/audio/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/midi/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/color/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/parameter/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/pattern/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/effect/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/model/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/modulator/package-info.class
    [javac] Creating empty /Users/philihp/work/LX/examples/LXHeadless/bin/heronarts/lx/transform/package-info.class
      [jar] Building jar: /Users/philihp/work/LX/examples/LXHeadless/bin/LXHeadless.jar
```