### PR TITLE
OPCOutput causes ArrayIndexOutOfBoundsExceptions sometimes

### DIFF
--- a/LX/src/main/java/heronarts/lx/output/OPCOutput.java
+++ b/LX/src/main/java/heronarts/lx/output/OPCOutput.java
@@ -69,7 +69,7 @@ public class OPCOutput extends LXSocketOutput implements OPCConstants {
       int c = colors[this.indexBuffer[i]];
       this.packetData[dataOffset + OFFSET_R] = glut[(0xFF & (c >> 16))];
       this.packetData[dataOffset + OFFSET_G] = glut[(0xFF & (c >> 8))];
-      this.packetData[dataOffset + OFFSET_B] = glut[(byte) (0xFF & c)];
+      this.packetData[dataOffset + OFFSET_B] = glut[(0xFF & c)];
     }
     return this.packetData;
   }


### PR DESCRIPTION
I discovered this while playing around with the headless mode.  Without changing anything, and monitoring the output with openpixelcontrol, I got the following error:
```
Exception in thread "LXEngine Render Thread" java.lang.ArrayIndexOutOfBoundsException: Index -126 out of bounds for length 256
	at heronarts.lx.output.OPCOutput.getPacketData(Unknown Source)
	at heronarts.lx.output.LXSocketOutput.onSend(Unknown Source)
	at heronarts.lx.output.LXOutput.onSend(Unknown Source)
	at heronarts.lx.output.LXOutput.send(Unknown Source)
	at heronarts.lx.output.LXOutput.send(Unknown Source)
	at heronarts.lx.output.LXOutput.send(Unknown Source)
	at heronarts.lx.LXEngine.run(Unknown Source)
	at heronarts.lx.LXEngine$EngineThread.run(Unknown Source)
```

I narrowed it down to line 72 in `OPCOutput.java`, where the blue value is typecast to a `byte`.  If the blue value is greater than 127, it gets shifted to a negative number.  I'm not sure why the typecast is there, but it seems to me that it's a bug, since blue values should be able to go up to 255.  Removing the byte typecast doesn't seem to cause any issues.