### PR TITLE
Find correct midi output when using two devices of same name.

### DIFF
--- a/src/main/java/heronarts/lx/midi/LXMidiDevice.java
+++ b/src/main/java/heronarts/lx/midi/LXMidiDevice.java
@@ -106,6 +106,15 @@ public abstract class LXMidiDevice {
   }
 
   /**
+   * Get the unique name of the device.
+   *
+   * @return Unique device name
+   */
+  public String getNameUnique() {
+    return LXMidiEngine.getDeviceNameUnique(this.device.getDeviceInfo());
+  }
+
+  /**
    * Get a description of this device
    *
    * @return Device description

--- a/src/main/java/heronarts/lx/midi/LXMidiEngine.java
+++ b/src/main/java/heronarts/lx/midi/LXMidiEngine.java
@@ -34,6 +34,7 @@ import heronarts.lx.osc.LXOscComponent;
 import heronarts.lx.osc.OscMessage;
 import heronarts.lx.parameter.BooleanParameter;
 import heronarts.lx.parameter.LXParameter;
+import uk.co.xfactorylibrarians.coremidi4j.CoreMidiDeviceInfo;
 import uk.co.xfactorylibrarians.coremidi4j.CoreMidiDeviceProvider;
 import uk.co.xfactorylibrarians.coremidi4j.CoreMidiException;
 import uk.co.xfactorylibrarians.coremidi4j.CoreMidiNotification;
@@ -365,7 +366,7 @@ public class LXMidiEngine extends LXComponent implements LXOscComponent {
         if ((existingInput == null) && (existingOutput == null)) {
           try {
             final MidiDevice device = MidiSystem.getMidiDevice(deviceInfo);
-            String deviceName = getDeviceName(deviceInfo);
+            String deviceName = getDeviceNameUnique(deviceInfo);
             if (device.getMaxTransmitters() != 0) {
               LXMidiInput input = findInput(deviceName);
               if (input != null) {
@@ -472,6 +473,14 @@ public class LXMidiEngine extends LXComponent implements LXOscComponent {
     String name = deviceInfo.getName();
     if (name.indexOf(COREMIDI4J_HEADER) == 0) {
       name = name.substring(COREMIDI4J_HEADER.length());
+    }
+    return name;
+  }
+
+  public static String getDeviceNameUnique(MidiDevice.Info deviceInfo) {
+    String name = getDeviceName(deviceInfo);
+    if (deviceInfo instanceof CoreMidiDeviceInfo) {
+      name += ((CoreMidiDeviceInfo) deviceInfo).getdeviceUniqueID();
     }
     return name;
   }
@@ -599,7 +608,7 @@ public class LXMidiEngine extends LXComponent implements LXOscComponent {
 
   private <T extends LXMidiDevice> T matchDevice(List<T> devices, String[] names) {
     for (T device : devices) {
-      String deviceName = device.getName();
+      String deviceName = device.getNameUnique();
       for (String name : names) {
         if (deviceName.contains(name)) {
           return device;
@@ -610,7 +619,7 @@ public class LXMidiEngine extends LXComponent implements LXOscComponent {
   }
 
   private LXMidiOutput findOutput(LXMidiInput input) {
-    return findDevice(this.mutableOutputs, input.getName());
+    return findDevice(this.mutableOutputs, input.getNameUnique());
   }
 
   public LXMidiOutput findOutput(String name) {
@@ -623,7 +632,7 @@ public class LXMidiEngine extends LXComponent implements LXOscComponent {
 
   private <T extends LXMidiDevice> T findDevice(List<T> devices, String name) {
     for (T device : devices) {
-      if (device.getName().equals(name)) {
+      if (device.getNameUnique().equals(name)) {
         return device;
       }
     }


### PR DESCRIPTION
A proposed direction for this problem.  Uses a hidden unique deviceID to match midi outputs to midi inputs.  This works on a fresh project file.  However it crashes when loading from a saved file.  Could use your input on whether you like this direction before taking it any further.

The unique id remains constant across multiple runs of LX but I suspect it is only unique to the running instance of OSX. In which case if we write the uniqueId to a saved project file, we need to handle the ids having changes after a computer restart. Suspect the solution here would be to pair the saved instances sequentially with current instances of the same midi device. Could use your assistance with this one for sake of efficiency.