### PR TITLE
Bug fix: byte order W sending minimum rgb value instead of composite.

### DIFF
--- a/src/main/java/heronarts/lx/output/LXBufferOutput.java
+++ b/src/main/java/heronarts/lx/output/LXBufferOutput.java
@@ -19,6 +19,7 @@
 package heronarts.lx.output;
 
 import heronarts.lx.LX;
+import heronarts.lx.utils.LXUtils;
 
 public abstract class LXBufferOutput extends LXOutput {
 
@@ -127,7 +128,7 @@ public abstract class LXBufferOutput extends LXOutput {
             int r = ((color >> 16) & 0xff);
             int g = ((color >> 8) & 0xff);
             int b = (color & 0xff);
-            int w = (r < g) ? ((r < b) ? r : b) : ((g < b) ? g : b);
+            int w = LXUtils.constrain((r + b + g) / 3, 0, 255);
             buffer[offset] = gamma[w];
             offset += numBytes;
           }

--- a/src/main/java/heronarts/lx/output/LXBufferOutput.java
+++ b/src/main/java/heronarts/lx/output/LXBufferOutput.java
@@ -128,7 +128,7 @@ public abstract class LXBufferOutput extends LXOutput {
             int r = ((color >> 16) & 0xff);
             int g = ((color >> 8) & 0xff);
             int b = (color & 0xff);
-            int w = LXUtils.constrain((r + b + g) / 3, 0, 255);
+            int w = (r + b + g) / 3;
             buffer[offset] = gamma[w];
             offset += numBytes;
           }


### PR DESCRIPTION
Looks like a copy and paste error from the RGBW section below it.  This was sending the minimum value of (r,g,b) to w which on a fully saturated color was often zero.  This fix sets it to the average, although some sources online say it should be an uneven weighting formula such as (W = R^gamma * .2126 + G^gamma * .7152 + B^gamma * .0722).