### PR TITLE
APC40MkII bug fix and clip handling

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -368,6 +368,11 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
         int focusedPatternIndex = c.getFocusedPatternIndex();
         c.controlSurfaceFocusIndex.setValue(focusedPatternIndex < CLIP_LAUNCH_ROWS ? 0 : (focusedPatternIndex - CLIP_LAUNCH_ROWS + 1));
       }
+      for (LXClip clip : this.channel.clips) {
+        if (clip != null) {
+          clip.running.addListener(this);
+        }
+      }
     }
 
     public void dispose() {


### PR DESCRIPTION
Fixed bug: surface failed to register listeners to existing clips on enable or load from file.

For single property change on a clip: only refresh associated button not entire channel.  It's possible there's a cleaner way to do this... it feels slightly odd due to needing both the clip index and channel index to locate the button.