### PR TITLE
Fix crash on midi send after unplug

### DIFF
--- a/src/main/java/heronarts/lx/midi/LXMidiOutput.java
+++ b/src/main/java/heronarts/lx/midi/LXMidiOutput.java
@@ -56,10 +56,16 @@ public class LXMidiOutput extends LXMidiDevice implements Receiver {
     if (!this.enabled.isOn()) {
       throw new UnsupportedOperationException("Cannot send() to an LXMidiOutput that is not enabled");
     }
+    if (!this.connected.isOn()) {
+      return;
+    }
     this.receiver.send(message, timeStamp);
   }
 
   public void sendSysex(byte[] sysex) {
+    if (!this.connected.isOn()) {
+      return;
+    }
     try {
       SysexMessage message = new SysexMessage();
       message.setMessage(sysex, sysex.length);
@@ -70,6 +76,9 @@ public class LXMidiOutput extends LXMidiDevice implements Receiver {
   }
 
   private void sendShortMessage(int command, int channel, int data1, int data2) {
+    if (!this.connected.isOn()) {
+      return;
+    }
     try {
       ShortMessage message = new ShortMessage();
       message.setMessage(command, channel, data1, data2);

--- a/src/main/java/heronarts/lx/midi/surface/LXMidiSurface.java
+++ b/src/main/java/heronarts/lx/midi/surface/LXMidiSurface.java
@@ -102,6 +102,8 @@ public abstract class LXMidiSurface implements LXMidiListener, LXSerializable {
         this.input.open();
         this.output.open();
         onReconnect();
+      } else {
+        onDisconnect();
       }
     });
   }
@@ -124,6 +126,11 @@ public abstract class LXMidiSurface implements LXMidiListener, LXSerializable {
    * @param isOn Whether surface is enabled
    */
   protected void onEnable(boolean isOn) {}
+
+  /**
+   * Subclasses may override, invoked when the control surface is disconnected.
+   */
+  protected void onDisconnect() {}
 
   /**
    * Subclasses may override, invoked when the control surface was disconnected but

--- a/src/main/java/heronarts/lx/parameter/LXListenableParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXListenableParameter.java
@@ -223,7 +223,7 @@ public abstract class LXListenableParameter implements LXParameter {
   }
 
   public final boolean isDefault() {
-    return this.getValue() == this.defaultValue;
+    return getValue() == this.defaultValue;
   }
 
   public String getLabel() {


### PR DESCRIPTION
There are a few ways to fix this, so sending this simple version to demonstrate the problem.

After a midi device is hot-unplugged the following actions will cause a fatal crash due to disconnected midi output:
-Unchecking the Enabled box in the midi list, which on APC40mkII attempts to set device controls to zero and send sysex for generic mode.
-Changing channel focus, adding a pattern, etc, which fires listeners on midi surfaces which in turn attempt to send notes.

Possible solutions:
-Swallow the send attempts as per this solution, which doesn't feel exactly right but fixes all existing surfaces.
-Require surfaces to monitor connected state by overriding this new onDisconnect() method and not send if disconnected.  Seems redundant to make each surface do the tracking of the state.
-Maintain connected state flag in LXMidiSurface and make accessible to subclasses with method.  Require surfaces to check state using LXMidiSurface.isConnected() or similar each time before attempting send() or sendSysex().