### PR TITLE
Midi surfaces accommodate null remote controls from device

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APC40.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40.java
@@ -265,12 +265,16 @@ public class APC40 extends LXMidiSurface implements LXMidiSurface.Bidirectional 
               break;
             }
             this.knobs[i] = parameter;
-            parameter.addListener(this);
-            sendControlChange(0, DEVICE_KNOB_STYLE + i, parameter.getPolarity() == LXParameter.Polarity.BIPOLAR ? LED_STYLE_BIPOLAR : LED_STYLE_UNIPOLAR);
-            double normalized = (parameter instanceof CompoundParameter) ?
-              ((CompoundParameter) parameter).getBaseNormalized() :
-              parameter.getNormalized();
-            sendControlChange(0, DEVICE_KNOB + i, (int) (normalized * 127));
+            if (parameter != null) {
+              parameter.addListener(this);
+              sendControlChange(0, DEVICE_KNOB_STYLE + i, parameter.getPolarity() == LXParameter.Polarity.BIPOLAR ? LED_STYLE_BIPOLAR : LED_STYLE_UNIPOLAR);
+              double normalized = (parameter instanceof CompoundParameter) ?
+                ((CompoundParameter) parameter).getBaseNormalized() :
+                parameter.getNormalized();
+              sendControlChange(0, DEVICE_KNOB + i, (int) (normalized * 127));
+            } else {
+              sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_OFF);
+            }
             ++i;
           }
           this.device.controlSurfaceSemaphore.increment();

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -253,12 +253,16 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
               break;
             }
             this.knobs[i] = parameter;
-            parameter.addListener(this);
-            sendControlChange(0, DEVICE_KNOB_STYLE + i, parameter.getPolarity() == LXParameter.Polarity.BIPOLAR ? LED_STYLE_BIPOLAR : LED_STYLE_UNIPOLAR);
-            double normalized = (parameter instanceof CompoundParameter) ?
-              ((CompoundParameter) parameter).getBaseNormalized() :
-              parameter.getNormalized();
-            sendControlChange(0, DEVICE_KNOB + i, (int) (normalized * 127));
+            if (parameter != null) {
+              parameter.addListener(this);
+              sendControlChange(0, DEVICE_KNOB_STYLE + i, parameter.getPolarity() == LXParameter.Polarity.BIPOLAR ? LED_STYLE_BIPOLAR : LED_STYLE_UNIPOLAR);
+              double normalized = (parameter instanceof CompoundParameter) ?
+                ((CompoundParameter) parameter).getBaseNormalized() :
+                parameter.getNormalized();
+              sendControlChange(0, DEVICE_KNOB + i, (int) (normalized * 127));
+            } else {
+              sendControlChange(0, DEVICE_KNOB_STYLE + i, LED_STYLE_OFF);
+            }
             ++i;
           }
           this.device.controlSurfaceSemaphore.increment();

--- a/src/main/java/heronarts/lx/midi/surface/APCmini.java
+++ b/src/main/java/heronarts/lx/midi/surface/APCmini.java
@@ -263,12 +263,19 @@ public class APCmini extends LXMidiSurface implements LXMidiSurface.Bidirectiona
               break;
             }
             this.knobs[i] = parameter;
-            parameter.addListener(this);
-            if (gridMode == GridMode.PARAMETERS) {
-              int patternButton = getPatternButton(i);
-              sendNoteOn(MIDI_CHANNEL, patternButton, LED_PARAMETER_INCREMENT);
-              sendNoteOn(MIDI_CHANNEL, patternButton - CLIP_LAUNCH_COLUMNS, LED_PARAMETER_DECREMENT);
-              sendNoteOn(MIDI_CHANNEL, patternButton - (CLIP_LAUNCH_COLUMNS * 2), parameter.isDefault() ? LED_PARAMETER_ISDEFAULT : LED_PARAMETER_RESET);
+            int patternButton = getPatternButton(i);
+            if (parameter != null) {
+              parameter.addListener(this);
+              if (gridMode == GridMode.PARAMETERS) {
+                sendNoteOn(MIDI_CHANNEL, patternButton, LED_PARAMETER_INCREMENT);
+                sendNoteOn(MIDI_CHANNEL, patternButton - CLIP_LAUNCH_COLUMNS, LED_PARAMETER_DECREMENT);
+                sendNoteOn(MIDI_CHANNEL, patternButton - (CLIP_LAUNCH_COLUMNS * 2), parameter.isDefault() ? LED_PARAMETER_ISDEFAULT : LED_PARAMETER_RESET);
+                sendNoteOn(MIDI_CHANNEL, patternButton - (CLIP_LAUNCH_COLUMNS * 3), LED_OFF);
+              }
+            } else {
+              sendNoteOn(MIDI_CHANNEL, patternButton, LED_OFF);
+              sendNoteOn(MIDI_CHANNEL, patternButton - CLIP_LAUNCH_COLUMNS, LED_OFF);
+              sendNoteOn(MIDI_CHANNEL, patternButton - (CLIP_LAUNCH_COLUMNS * 2), LED_OFF);
               sendNoteOn(MIDI_CHANNEL, patternButton - (CLIP_LAUNCH_COLUMNS * 3), LED_OFF);
             }
             ++i;

--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -267,28 +267,36 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
               break;
             }
             this.knobs[i] = parameter;
-            parameter.addListener(this);
-            sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_ANIMATION_NONE);
-            sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_BRIGHTNESS_MAX);
-            double normalized = (parameter instanceof CompoundParameter) ?
-              ((CompoundParameter) parameter).getBaseNormalized() :
-              parameter.getNormalized();
-            sendControlChange(CHANNEL_ROTARY_ENCODER, DEVICE_KNOB + i, (int) (normalized * 127));
-            sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_BRIGHTNESS_MAX);
-            if (parameter instanceof CompoundParameter && ((CompoundParameter)parameter).modulations.size()>0) {
-              LXCompoundModulation modulation = ((CompoundParameter)parameter).modulations.get(0);
-              // TODO: color conversion not working
-              DiscreteColorParameter modulationColor = modulation.color;
-              int modColor = modulationColor.getColor();
-              float h = LXColor.h(modColor);
-              h = h * 125.f / 360.f;
-              h += 1.f;
-              int hInt = (int)h;
-              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_PULSE_EVERY_2_BEATS);
-              sendControlChange(CHANNEL_SWITCH_AND_COLOR, DEVICE_KNOB + i, hInt);
+            if (parameter != null) {
+              parameter.addListener(this);
+              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_ANIMATION_NONE);
+              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_BRIGHTNESS_MAX);
+              double normalized = (parameter instanceof CompoundParameter) ?
+                ((CompoundParameter) parameter).getBaseNormalized() :
+                parameter.getNormalized();
+              sendControlChange(CHANNEL_ROTARY_ENCODER, DEVICE_KNOB + i, (int) (normalized * 127));
+              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_BRIGHTNESS_MAX);
+              if (parameter instanceof CompoundParameter && ((CompoundParameter)parameter).modulations.size()>0) {
+                LXCompoundModulation modulation = ((CompoundParameter)parameter).modulations.get(0);
+                // TODO: color conversion not working
+                DiscreteColorParameter modulationColor = modulation.color;
+                int modColor = modulationColor.getColor();
+                float h = LXColor.h(modColor);
+                h = h * 125.f / 360.f;
+                h += 1.f;
+                int hInt = (int)h;
+                sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_PULSE_EVERY_2_BEATS);
+                sendControlChange(CHANNEL_SWITCH_AND_COLOR, DEVICE_KNOB + i, hInt);
+              } else {
+                sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_ANIMATION_NONE);
+                sendControlChange(CHANNEL_SWITCH_AND_COLOR, DEVICE_KNOB + i, 50);
+              }
             } else {
               sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_ANIMATION_NONE);
-              sendControlChange(CHANNEL_SWITCH_AND_COLOR, DEVICE_KNOB + i, 50);
+              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_ANIMATION_NONE);
+              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_BRIGHTNESS_25);
+              sendControlChange(CHANNEL_ROTARY_ENCODER, DEVICE_KNOB+i, 0);
+              sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_BRIGHTNESS_OFF);
             }
             ++i;
           }


### PR DESCRIPTION
Update midi surfaces to handle null entries in the list of parameters returned by LXDeviceComponent.getRemoteControls().  Devices can now use null as a placeholder when aligning parameters with physical knobs on midi surfaces.  This eliminates the need to use "dummy" placeholder parameters.

Tested and working w/ APC40mkII, APCmini, and MFT.