### PR TITLE
Clip-loop features for the APC40Mk2

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -436,6 +436,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       for (LXClip clip : this.channel.clips) {
         if (clip != null) {
           clip.running.addListener(this);
+          clip.loop.addListener(this);
         }
       }
     }
@@ -460,6 +461,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       for (LXClip clip : this.channel.clips) {
         if (clip != null) {
           clip.running.removeListener(this);
+          clip.loop.removeListener(this);
         }
       }
     }
@@ -549,12 +551,14 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     @Override
     public void clipAdded(LXBus bus, LXClip clip) {
       clip.running.addListener(this);
+      clip.loop.addListener(this);
       sendClip(this.channel.getIndex(), this.channel, clip.getIndex(), clip);
     }
 
     @Override
     public void clipRemoved(LXBus bus, LXClip clip) {
       clip.running.removeListener(this);
+      clip.loop.removeListener(this);
       sendChannelClips(this.channel.getIndex(), this.channel);
     }
 
@@ -1108,10 +1112,10 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
           } else {
             LXClip clip = channel.getClip(index);
             if (clip == null) {
-              channel.addClip(index, this.shiftOn);
+              clip = channel.addClip(index);
+              clip.loop.setValue(this.shiftOn);
             } else if (this.shiftOn) {
               clip.loop.toggle();
-              sendClip(channelIndex, channel, index, clip);
             } else if (clip.isRunning()) {
               clip.stop();
             } else {

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -152,6 +152,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
   public static final int LED_OFF = 0;
   public static final int LED_ON = 1;
   public static final int LED_GRAY = 2;
+  public static final int LED_CYAN = 114;
   public static final int LED_GRAY_DIM = 117;
   public static final int LED_RED = 120;
   public static final int LED_RED_HALF = 121;
@@ -748,12 +749,14 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     int mode = LED_MODE_PRIMARY;
     int pitch = CLIP_LAUNCH + channelIndex + CLIP_LAUNCH_COLUMNS * (CLIP_LAUNCH_ROWS - 1 - clipIndex);
     if (channel != null && clip != null) {
-      color = channel.arm.isOn() ? LED_RED_HALF : LED_GRAY;
+      color = channel.arm.isOn() ? LED_RED_HALF :
+              clip.loop.isOn() ? LED_CYAN : LED_GRAY;
       if (clip.isRunning()) {
         color = channel.arm.isOn() ? LED_RED : LED_GREEN;
         sendNoteOn(LED_MODE_PRIMARY, pitch, color);
         mode = LED_MODE_PULSE;
-        color = channel.arm.isOn() ? LED_RED_HALF : LED_GREEN_HALF;
+        color = channel.arm.isOn() ? LED_RED_HALF :
+                clip.loop.isOn() ? LED_CYAN : LED_GREEN_HALF;
       }
     }
     sendNoteOn(mode, pitch, color);
@@ -1105,14 +1108,15 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
           } else {
             LXClip clip = channel.getClip(index);
             if (clip == null) {
-              clip = channel.addClip(index);
+              channel.addClip(index);
+            } else if (this.shiftOn) {
+              clip.loop.toggle();
+              sendClip(channelIndex, channel, index, clip);
+            } else if (clip.isRunning()) {
+              clip.stop();
             } else {
-              if (clip.isRunning()) {
-                clip.stop();
-              } else {
-                clip.trigger();
-                this.lx.engine.clips.setFocusedClip(clip);
-              }
+              clip.trigger();
+              this.lx.engine.clips.setFocusedClip(clip);
             }
           }
         }

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1108,7 +1108,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
           } else {
             LXClip clip = channel.getClip(index);
             if (clip == null) {
-              channel.addClip(index);
+              channel.addClip(index, this.shiftOn);
             } else if (this.shiftOn) {
               clip.loop.toggle();
               sendClip(channelIndex, channel, index, clip);

--- a/src/main/java/heronarts/lx/mixer/LXBus.java
+++ b/src/main/java/heronarts/lx/mixer/LXBus.java
@@ -333,10 +333,14 @@ public abstract class LXBus extends LXModelComponent implements LXOscComponent {
   }
 
   public LXClip addClip() {
-    return addClip(this.mutableClips.size());
+    return addClip(this.mutableClips.size(), false);
   }
 
   public LXClip addClip(int index) {
+    return addClip(index, false);
+  }
+
+  public LXClip addClip(int index, boolean loop) {
     if (getClip(index) != null) {
       throw new IllegalStateException("Cannot add clip at index " + index + " which already holds a clip: " + this);
     }
@@ -345,6 +349,7 @@ public abstract class LXBus extends LXModelComponent implements LXOscComponent {
     }
     LXClip clip = constructClip(index);
     clip.label.setValue("Clip-" + (index+1));
+    clip.loop.setValue(loop);
     this.mutableClips.set(index, clip);
     for (ClipListener listener : this.clipListeners) {
       listener.clipAdded(this, clip);

--- a/src/main/java/heronarts/lx/mixer/LXBus.java
+++ b/src/main/java/heronarts/lx/mixer/LXBus.java
@@ -333,14 +333,10 @@ public abstract class LXBus extends LXModelComponent implements LXOscComponent {
   }
 
   public LXClip addClip() {
-    return addClip(this.mutableClips.size(), false);
+    return addClip(this.mutableClips.size());
   }
 
   public LXClip addClip(int index) {
-    return addClip(index, false);
-  }
-
-  public LXClip addClip(int index, boolean loop) {
     if (getClip(index) != null) {
       throw new IllegalStateException("Cannot add clip at index " + index + " which already holds a clip: " + this);
     }
@@ -349,7 +345,6 @@ public abstract class LXBus extends LXModelComponent implements LXOscComponent {
     }
     LXClip clip = constructClip(index);
     clip.label.setValue("Clip-" + (index+1));
-    clip.loop.setValue(loop);
     this.mutableClips.set(index, clip);
     for (ClipListener listener : this.clipListeners) {
       listener.clipAdded(this, clip);


### PR DESCRIPTION
On the APC40Mk2, you can now hold SHIFT and click a clip to toggle whether it loops. This works whether it's currently playing or not.

When idle, clips that loop show up in a slightly more cyan shade of gray than the one used for non-looping clips. When playing, they pulse between green and cyan rather than green and off.