### PR TITLE
WIP: Add hooks so apps can grab colors from APC

### DIFF
--- a/src/main/java/heronarts/lx/LX.java
+++ b/src/main/java/heronarts/lx/LX.java
@@ -31,7 +31,7 @@ import heronarts.lx.output.LXOutput;
 import heronarts.lx.parameter.MutableParameter;
 import heronarts.lx.parameter.StringParameter;
 import heronarts.lx.pattern.LXPattern;
-import heronarts.lx.pattern.color.SolidPattern;
+import heronarts.lx.pattern.color.NewSolidPattern;
 import heronarts.lx.scheduler.LXScheduler;
 import heronarts.lx.structure.LXFixture;
 import heronarts.lx.structure.LXStructure;
@@ -897,7 +897,7 @@ public class LX {
       }
       this.engine.load(this, new JsonObject());
 
-      LXChannel channel = this.engine.mixer.addChannel(new LXPattern[] { new SolidPattern(this, 0xffff0000) });
+      LXChannel channel = this.engine.mixer.addChannel(new LXPattern[] { new NewSolidPattern(this, 0xffff0000) });
       channel.fader.setValue(1);
 
       setProject(null, ProjectListener.Change.NEW);

--- a/src/main/java/heronarts/lx/LXComponent.java
+++ b/src/main/java/heronarts/lx/LXComponent.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import com.google.gson.JsonObject;
 import heronarts.lx.color.ColorParameter;
 import heronarts.lx.color.DiscreteColorParameter;
+import heronarts.lx.color.LinkableColorParameter;
 import heronarts.lx.modulation.LXModulationContainer;
 import heronarts.lx.osc.LXOscComponent;
 import heronarts.lx.osc.LXOscEngine;
@@ -884,10 +885,18 @@ public abstract class LXComponent implements LXPath, LXParameterListener, LXSeri
     }
     if (parameter instanceof ColorParameter) {
       // NOTE: order is important, brightness must be saved/loaded first
+      // TODO: Why?
       ColorParameter colorParameter = (ColorParameter) parameter;
       addParameter(path + "/" + ColorParameter.PATH_BRIGHTNESS, colorParameter.brightness);
       addParameter(path + "/" + ColorParameter.PATH_SATURATION, colorParameter.saturation);
       addParameter(path + "/" + ColorParameter.PATH_HUE, colorParameter.hue);
+    }
+    if (parameter instanceof LinkableColorParameter) {
+      LinkableColorParameter linkableColorParameter = (LinkableColorParameter) parameter;
+      addParameter(path + "/" + LinkableColorParameter.PATH_SWATCH_NUMBER,
+              linkableColorParameter.swatchNumber);
+      addParameter(path + "/" + LinkableColorParameter.PATH_SWATCH_COLOR_NUMBER,
+              linkableColorParameter.swatchColorNumber);
     }
     return this;
   }

--- a/src/main/java/heronarts/lx/LXRegistry.java
+++ b/src/main/java/heronarts/lx/LXRegistry.java
@@ -112,7 +112,7 @@ public class LXRegistry implements LXSerializable {
   static {
     DEFAULT_PATTERNS = new ArrayList<Class<? extends LXPattern>>();
     DEFAULT_PATTERNS.add(heronarts.lx.pattern.color.GradientPattern.class);
-    DEFAULT_PATTERNS.add(heronarts.lx.pattern.color.SolidPattern.class);
+    DEFAULT_PATTERNS.add(heronarts.lx.pattern.color.NewSolidPattern.class);
     DEFAULT_PATTERNS.add(heronarts.lx.pattern.form.PlanesPattern.class);
     DEFAULT_PATTERNS.add(heronarts.lx.pattern.texture.NoisePattern.class);
     DEFAULT_PATTERNS.add(heronarts.lx.pattern.texture.SparklePattern.class);

--- a/src/main/java/heronarts/lx/color/ColorParameter.java
+++ b/src/main/java/heronarts/lx/color/ColorParameter.java
@@ -33,7 +33,7 @@ public class ColorParameter extends LXListenableParameter implements LXParameter
   public static final String PATH_SATURATION = "saturation";
   public static final String PATH_BRIGHTNESS = "brightness";
 
-  private int color;
+  protected int color;
   private boolean internalValueUpdate = false;
   private boolean internalHsbUpdate = false;
 
@@ -53,6 +53,9 @@ public class ColorParameter extends LXListenableParameter implements LXParameter
     this.hue.addListener(this);
     this.saturation.addListener(this);
     this.brightness.addListener(this);
+    this.hue.parentParameter = this;
+    this.saturation.parentParameter = this;
+    this.brightness.parentParameter = this;
     this.color = color;
   }
 
@@ -71,7 +74,7 @@ public class ColorParameter extends LXListenableParameter implements LXParameter
   }
 
   public String getHexString() {
-    return String.format("0x%08x", this.color);
+    return String.format("0x%08x", this.getColor());
   }
 
   @Override

--- a/src/main/java/heronarts/lx/color/LinkableColorParameter.java
+++ b/src/main/java/heronarts/lx/color/LinkableColorParameter.java
@@ -1,0 +1,71 @@
+package heronarts.lx.color;
+
+import heronarts.lx.LX;
+import heronarts.lx.parameter.DiscreteParameter;
+
+public class LinkableColorParameter extends ColorParameter {
+  public static final int NO_SWATCH = -2;
+  public static final int MASTER_SWATCH = -1;
+
+  private final LX lx;
+  public final DiscreteParameter swatchNumber;
+  public final DiscreteParameter swatchColorNumber;
+
+  public static final String PATH_SWATCH_NUMBER = "swatchNumber";
+  public static final String PATH_SWATCH_COLOR_NUMBER = "swatchColorNumber";
+
+  public LinkableColorParameter(LX lx, String label) {
+    this(lx, label, 0xff000000);
+  }
+
+  public LinkableColorParameter(LX lx, String label, int color) {
+    super(label, color);
+    this.lx = lx;
+
+    // TODO: There is no maximum number of swatches, so the 8 here is arbitrary.
+    this.swatchNumber = new DiscreteParameter("Swatch", NO_SWATCH,-2, 8)
+            .setDescription("Which swatch to draw colors from (-1 for main, -2 for none)");
+
+    this.swatchColorNumber = new DiscreteParameter("Index", 0,0,
+            LXSwatch.MAX_COLORS)
+            .setDescription("Which color in that swatch to draw from");
+
+    this.swatchNumber.addListener(this);
+    this.swatchColorNumber.addListener(this);
+
+    this.swatchNumber.parentParameter = this;
+    this.swatchColorNumber.parentParameter = this;
+  }
+
+
+  @Override
+  public LinkableColorParameter setDescription(String description) {
+    return (LinkableColorParameter) super.setDescription(description);
+  }
+
+  @Override
+  public int getColor() {
+    int swatchNum = this.swatchNumber.getValuei();
+    if (swatchNum == NO_SWATCH) {
+      return this.color;
+    }
+    LXSwatch swatch;
+    int numSwatches = this.lx.engine.palette.swatches.size();
+    if (swatchNum == MASTER_SWATCH) {
+      swatch = this.lx.engine.palette.swatch;
+    } else if (swatchNum < numSwatches) {
+      swatch = this.lx.engine.palette.swatches.get(swatchNum);
+    } else {
+      swatch = this.lx.engine.palette.swatches.get(numSwatches - 1);
+    }
+    return swatch.getColor(this.swatchColorNumber.getValuei()).color.getColor();
+  }
+
+  @Override
+  public void dispose() {
+    this.swatchNumber.removeListener(this);
+    this.swatchColorNumber.removeListener(this);
+    super.dispose();
+  }
+
+}

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1414,7 +1414,11 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       }
       this.colorClipboard = this.focusColor.primary.getColor();
       if (this.gridMode == GridMode.PALETTE) {
-        sendSwatches();
+        if (this.rainbowMode) {
+          sendSwatch(MASTER_SWATCH);
+        } else {
+          sendSwatches();
+        }
       }
       return;
     case CHANNEL_FADER:

--- a/src/main/java/heronarts/lx/parameter/LXListenableParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXListenableParameter.java
@@ -40,6 +40,8 @@ public abstract class LXListenableParameter implements LXParameter {
   private final List<LXParameterListener> listeners = new ArrayList<LXParameterListener>();
 
   private LXComponent parent;
+  public LXListenableParameter parentParameter = null;
+
   private String path;
 
   private Units units = Units.NONE;

--- a/src/main/java/heronarts/lx/pattern/color/NewSolidPattern.java
+++ b/src/main/java/heronarts/lx/pattern/color/NewSolidPattern.java
@@ -35,34 +35,6 @@ public class NewSolidPattern extends LXPattern {
     super(lx);
     this.color = new LinkableColorParameter(lx, "Color", color);
     addParameter("color", this.color);
-
-/*
-    final LXParameterListener checkAPC = (p) -> {
-      APC40Mk2 apcSurface = (APC40Mk2) lx.engine.midi.findSurface("APC40 mkII");
-      if (apcSurface != null) {
-        APC40Mk2.ActiveColor activeColor = apcSurface.activeColor();
-        Integer newColor = null;
-        if (activeColor.color != null) {
-          this.colorMode.setValue(ColorMode.FIXED);
-          newColor = activeColor.color;
-        } else if (activeColor.source != null) {
-          LXSwatch swatch = activeColor.source.getSwatch();
-          this.colorMode.setValue(ColorMode.PALETTE);
-          int index = swatch.getIndex();
-          this.paletteIndex.setValue(index);
-          newColor = swatch.getColor(index).primary.getColor();
-        }
-        if (newColor != null) {
-          LX.log("This is where we'd set the color to " + newColor);
-          // ...except that seems to lead to a stack overflow
-        }
-      }
-    };
-    this.color.addListener(checkAPC);
-    this.colorMode.addListener(checkAPC);
-    this.paletteIndex.addListener(checkAPC);
-    */
-
   }
 
   @Override

--- a/src/main/java/heronarts/lx/pattern/color/NewSolidPattern.java
+++ b/src/main/java/heronarts/lx/pattern/color/NewSolidPattern.java
@@ -1,0 +1,72 @@
+/**
+ * Copyright 2013- Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ */
+
+package heronarts.lx.pattern.color;
+
+import heronarts.lx.LXCategory;
+import heronarts.lx.LX;
+import heronarts.lx.color.*;
+import heronarts.lx.pattern.LXPattern;
+
+@LXCategory(LXCategory.COLOR)
+public class NewSolidPattern extends LXPattern {
+  public final LinkableColorParameter color;
+
+  public NewSolidPattern(LX lx) {
+    this(lx, LXColor.RED);
+  }
+
+  public NewSolidPattern(LX lx, int color) {
+    super(lx);
+    this.color = new LinkableColorParameter(lx, "Color", color);
+    addParameter("color", this.color);
+
+/*
+    final LXParameterListener checkAPC = (p) -> {
+      APC40Mk2 apcSurface = (APC40Mk2) lx.engine.midi.findSurface("APC40 mkII");
+      if (apcSurface != null) {
+        APC40Mk2.ActiveColor activeColor = apcSurface.activeColor();
+        Integer newColor = null;
+        if (activeColor.color != null) {
+          this.colorMode.setValue(ColorMode.FIXED);
+          newColor = activeColor.color;
+        } else if (activeColor.source != null) {
+          LXSwatch swatch = activeColor.source.getSwatch();
+          this.colorMode.setValue(ColorMode.PALETTE);
+          int index = swatch.getIndex();
+          this.paletteIndex.setValue(index);
+          newColor = swatch.getColor(index).primary.getColor();
+        }
+        if (newColor != null) {
+          LX.log("This is where we'd set the color to " + newColor);
+          // ...except that seems to lead to a stack overflow
+        }
+      }
+    };
+    this.color.addListener(checkAPC);
+    this.colorMode.addListener(checkAPC);
+    this.paletteIndex.addListener(checkAPC);
+    */
+
+  }
+
+  @Override
+  public void run(double deltaMs) {
+    setColors(this.color.getColor());
+  }
+}

--- a/src/main/java/heronarts/lx/pattern/color/SolidPattern.java
+++ b/src/main/java/heronarts/lx/pattern/color/SolidPattern.java
@@ -24,12 +24,8 @@ import heronarts.lx.color.ColorParameter;
 import heronarts.lx.color.LXColor;
 import heronarts.lx.color.LXDynamicColor;
 import heronarts.lx.color.LXSwatch;
-import heronarts.lx.midi.surface.APC40Mk2;
-import heronarts.lx.midi.surface.APC40Mk2Colors;
-import heronarts.lx.midi.surface.LXMidiSurface;
 import heronarts.lx.parameter.DiscreteParameter;
 import heronarts.lx.parameter.EnumParameter;
-import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.pattern.LXPattern;
 
 @LXCategory(LXCategory.COLOR)
@@ -73,31 +69,6 @@ public class SolidPattern extends LXPattern {
     addParameter("color", this.color);
     addParameter("colorMode", this.colorMode);
     addParameter("paletteIndex", this.paletteIndex);
-
-    final LXParameterListener checkAPC = (p) -> {
-      APC40Mk2 apcSurface = (APC40Mk2) lx.engine.midi.findSurface("APC40 mkII");
-      if (apcSurface != null) {
-        APC40Mk2.ActiveColor activeColor = apcSurface.activeColor();
-        Integer newColor = null;
-        if (activeColor.color != null) {
-          this.colorMode.setValue(ColorMode.FIXED);
-          newColor = activeColor.color;
-        } else if (activeColor.source != null) {
-          LXSwatch swatch = activeColor.source.getSwatch();
-          this.colorMode.setValue(ColorMode.PALETTE);
-          int index = swatch.getIndex();
-          this.paletteIndex.setValue(index);
-          newColor = swatch.getColor(index).primary.getColor();
-        }
-        if (newColor != null) {
-          LX.log("This is where we'd set the color to " + newColor);
-          // ...except that seems to lead to a stack overflow
-        }
-      }
-    };
-    this.color.addListener(checkAPC);
-    this.colorMode.addListener(checkAPC);
-    this.paletteIndex.addListener(checkAPC);
   }
 
   public LXDynamicColor getPaletteColor() {


### PR DESCRIPTION
Added a hook into the APC40Mk2 driver so that app code can peek in and see if there's a color that was recently touched, and if so, whether it's a fixed value or a swatch entry. The changes to SolidPattern aren't actually intended to be checked in; they're just my attempt to show how an app could hook into this. 