### PR TITLE
Add color to swatch when unused master swatch button clicked in Apc40mkII palette mode

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1067,6 +1067,9 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
           // Make it the focusColor (i.e., turning the CUE LEVEL knob will tweak it), and
           // if there's a color on the clipboard, paste it here.
           LXSwatch swatch = getSwatch(MASTER_SWATCH);
+          if (index > swatch.colors.size()-1 && index < LXSwatch.MAX_COLORS) {
+            swatch.addColor();
+          }
           this.focusColor = swatch.getColor(index);
           if (this.colorClipboard != null) {
             this.focusColor.primary.setColor(this.colorClipboard);

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1066,13 +1066,18 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
           // A button corresponding to an entry in the main palette swatch has been tapped.
           // Make it the focusColor (i.e., turning the CUE LEVEL knob will tweak it), and
           // if there's a color on the clipboard, paste it here.
+          boolean colorChanged = false;
           LXSwatch swatch = getSwatch(MASTER_SWATCH);
           if (index > swatch.colors.size()-1 && index < LXSwatch.MAX_COLORS) {
             swatch.addColor();
+            colorChanged = true;
           }
           this.focusColor = swatch.getColor(index);
           if (this.colorClipboard != null) {
             this.focusColor.primary.setColor(this.colorClipboard);
+            colorChanged = true;
+          }
+          if (colorChanged) {
             sendSwatch(MASTER_SWATCH);
           }
         } else {
@@ -1092,11 +1097,22 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
 
         if (this.gridMode == GridMode.PALETTE) {
           LXSwatch swatch = getSwatch(channelIndex);
-          if (swatch != null && index < swatch.colors.size()) {
-            this.colorClipboard = swatch.colors.get(index).primary.getColor();
-          } else {
-            this.colorClipboard = null;
+          if (swatch != null) {
+            if (index < swatch.colors.size()) {
+              this.colorClipboard = swatch.colors.get(index).primary.getColor();
+            } else if (index < LXSwatch.MAX_COLORS) {
+              LXDynamicColor color = swatch.addColor();
+              if (this.colorClipboard != null) {
+                color.primary.setColor(this.colorClipboard);
+              } else {
+                this.colorClipboard = color.primary.getColor();
+              }
+              sendSwatch(channelIndex);
+            } else {
+              this.colorClipboard = null;
+            }
           }
+
           return;
         }
         LXAbstractChannel channel = getChannel(channelIndex);

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1112,7 +1112,6 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
               this.colorClipboard = null;
             }
           }
-
           return;
         }
         LXAbstractChannel channel = getChannel(channelIndex);


### PR DESCRIPTION
Just got to testing this new palette mode - very cool!  Quick mod here to allow a new color to be added to the current swatch by clicking one of the unused Scene Launch buttons.  Initializes to the clipboard color if one has been copied or the default color if not.

If initializing to the default color the button doesn't light up until cue level is adjusted.  Fine for now but will be cleaner once midi surface registers for the palette listeners.

Might be nice to choose a button as well to delete the focused color.  Maybe "Nudge -"?