### PR TITLE
Use relative knob changes on MFT and add incrementNormalized() to parameters

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -40,6 +40,7 @@ import heronarts.lx.parameter.LXListenableNormalizedParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.LXParameterListener;
 import heronarts.lx.pattern.LXPattern;
+import heronarts.lx.utils.LXUtils;
 
 public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.Bidirectional {
 
@@ -56,8 +57,9 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
    *     Right Button 2 Function: Next Bank
    *     Right Button 3 Function: CC Toggle
    * Encoder Settings (click Multiple, select all encoders):
+   *   Sensitivity: High Resolution
    *   Switch Action Type: CC Hold
-   *   Encoder MIDI Type: CC
+   *   Encoder MIDI Type: ENC 3FH/41H
    *   Encoder Switch MIDI Settings:
    *     Switch MIDI Channel: 2
    *     Switch MIDI Number: 6
@@ -80,6 +82,13 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
   public static final int DEVICE_KNOB = 0;
   public static final int DEVICE_KNOB_NUM = 64;
   public static final int DEVICE_KNOB_MAX = DEVICE_KNOB + DEVICE_KNOB_NUM;
+  public static final int KNOB_DECREMENT_VERYFAST = 61;
+  public static final int KNOB_DECREMENT_FAST = 62;
+  public static final int KNOB_DECREMENT = 63;
+  public static final int KNOB_INCREMENT = 65;
+  public static final int KNOB_INCREMENT_FAST = 66;
+  public static final int KNOB_INCREMENT_VERYFAST = 67;
+  public static final int KNOB_TICKS_PER_DISCRETE_INCREMENT = 8;
 
   // MIDI ControlChanges on System channel
   public static final int BANK1 = 0;
@@ -182,10 +191,12 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
 
     private final LXListenableNormalizedParameter[] knobs =
       new LXListenableNormalizedParameter[DEVICE_KNOB_NUM];
+    private final int[] knobTicks = new int[DEVICE_KNOB_NUM];
 
     DeviceListener() {
       for (int i = 0; i < this.knobs.length; ++i) {
         this.knobs[i] = null;
+        this.knobTicks[i] = 0;
       }
     }
 
@@ -267,6 +278,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
               break;
             }
             this.knobs[i] = parameter;
+            this.knobTicks[i] = 0;
             if (parameter != null) {
               parameter.addListener(this);
               sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_ANIMATION_NONE);
@@ -308,6 +320,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
           sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_BRIGHTNESS_25);
           sendControlChange(CHANNEL_ROTARY_ENCODER, DEVICE_KNOB+i, 0);
           sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_BRIGHTNESS_OFF);
+          this.knobTicks[i] = 0;
           ++i;
         }
 
@@ -337,9 +350,54 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       }
     }
 
+    private boolean isKnobRelative(int index) {
+      // Fixed for now but could be expanded to poll MFT encoder settings on startup with sysex
+      return true;
+    }
+
     private void onKnob(int index, double normalized) {
       if (this.knobs[index] != null) {
         this.knobs[index].setNormalized(normalized);
+      }
+    }
+
+    private final static double KNOB_INCREMENT_AMOUNT = 1.0/128.0;
+
+    private void onKnobDecrement(int index) {
+      LXListenableNormalizedParameter knob = this.knobs[index];
+      if (knob != null) {
+        if (knob instanceof DiscreteParameter) {
+          // Move after a set number of ticks in the same direction
+          this.knobTicks[index] = LXUtils.min(this.knobTicks[index], 0) - 1;
+          if (this.knobTicks[index] == 0-KNOB_TICKS_PER_DISCRETE_INCREMENT) {
+            this.knobTicks[index] = 0;
+            ((DiscreteParameter)knob).decrement();
+          }
+        } else {
+          onKnobIncrement(knob, 0-KNOB_INCREMENT_AMOUNT);
+        }
+      }
+    }
+
+    private void onKnobIncrement(int index) {
+      LXListenableNormalizedParameter knob = this.knobs[index];
+      if (knob != null) {
+        if (knob instanceof DiscreteParameter) {
+          // Move after a set number of ticks in the same direction
+          this.knobTicks[index] = LXUtils.max(this.knobTicks[index], 0) + 1;
+          if (this.knobTicks[index] == KNOB_TICKS_PER_DISCRETE_INCREMENT) {
+            this.knobTicks[index] = 0;
+            ((DiscreteParameter)knob).increment();
+          }
+        } else {
+          onKnobIncrement(knob, KNOB_INCREMENT_AMOUNT);
+        }
+      }
+    }
+
+    private void onKnobIncrement(LXListenableNormalizedParameter knob, double amount) {
+      if (knob != null) {
+        knob.incrementNormalized(amount);
       }
     }
 
@@ -490,9 +548,23 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
     switch (channel) {
       case CHANNEL_ROTARY_ENCODER:
         if (number >= DEVICE_KNOB && number <= DEVICE_KNOB_MAX) {
-            this.deviceListener.onKnob(number - DEVICE_KNOB, cc.getNormalized());
-            return;
+          int iKnob = number - DEVICE_KNOB;
+          if (this.deviceListener.isKnobRelative(iKnob)) {
+            if (note == KNOB_INCREMENT || note == KNOB_INCREMENT_FAST || note == KNOB_INCREMENT_VERYFAST) {
+              this.deviceListener.onKnobIncrement(iKnob);
+            } else if (note == KNOB_DECREMENT || note == KNOB_DECREMENT_FAST || note == KNOB_DECREMENT_VERYFAST) {
+              this.deviceListener.onKnobDecrement(iKnob);
+            } else {
+              // Knob sent absolute values but software is expecting relative values
+              LXMidiEngine.error("MFT Encoder MIDI Type should be ENC 3FH/41H for encoder " + number + ". Received note " + note);
+              // Let it through just to be nice
+              this.deviceListener.onKnob(iKnob, cc.getNormalized());
+            }
+          } else {
+            this.deviceListener.onKnob(iKnob, cc.getNormalized());
           }
+          return;
+        }
         LXMidiEngine.error("MFT Unknown Knob: " + number);
         break;
       case CHANNEL_SWITCH_AND_COLOR:

--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -529,20 +529,20 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
   public void controlChangeReceived(MidiControlChange cc) {
     int channel = cc.getChannel();
     int number = cc.getCC();
-    int note = cc.getValue();
+    int value = cc.getValue();
 
     switch (channel) {
       case CHANNEL_ROTARY_ENCODER:
         if (number >= DEVICE_KNOB && number <= DEVICE_KNOB_MAX) {
           int iKnob = number - DEVICE_KNOB;
           if (this.deviceListener.isKnobRelative(iKnob)) {
-            if (note == KNOB_INCREMENT || note == KNOB_INCREMENT_FAST || note == KNOB_INCREMENT_VERYFAST) {
+            if (value == KNOB_INCREMENT || value == KNOB_INCREMENT_FAST || value == KNOB_INCREMENT_VERYFAST) {
               this.deviceListener.onKnobIncrement(iKnob, true);
-            } else if (note == KNOB_DECREMENT || note == KNOB_DECREMENT_FAST || note == KNOB_DECREMENT_VERYFAST) {
+            } else if (value == KNOB_DECREMENT || value == KNOB_DECREMENT_FAST || value == KNOB_DECREMENT_VERYFAST) {
               this.deviceListener.onKnobIncrement(iKnob, false);
             } else {
               // Knob sent absolute values but software is expecting relative values
-              LXMidiEngine.error("MFT Encoder MIDI Type should be ENC 3FH/41H for encoder " + number + ". Received note " + note);
+              LXMidiEngine.error("MFT Encoder MIDI Type should be ENC 3FH/41H for encoder " + number + ". Received value " + value);
               // Let it through just to be nice
               this.deviceListener.onKnob(iKnob, cc.getNormalized());
             }
@@ -566,7 +566,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
           case BANK2:
           case BANK3:
           case BANK4:
-            if (note == BANK_ON)
+            if (value == BANK_ON)
                 updateBank(number);
             return;
           case BANK1_LEFT1:

--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -362,11 +362,6 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       }
     }
 
-    private boolean isKnobRelative(int index) {
-      // Fixed for now but could be expanded to poll MFT encoder settings on startup with sysex
-      return true;
-    }
-
     private void onKnob(int index, double normalized) {
       if (this.knobs[index] != null) {
         this.knobs[index].setNormalized(normalized);
@@ -566,18 +561,14 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       case CHANNEL_ROTARY_ENCODER:
         if (number >= DEVICE_KNOB && number <= DEVICE_KNOB_MAX) {
           int iKnob = number - DEVICE_KNOB;
-          if (this.deviceListener.isKnobRelative(iKnob)) {
-            if (value == KNOB_INCREMENT || value == KNOB_INCREMENT_FAST || value == KNOB_INCREMENT_VERYFAST) {
-              this.deviceListener.onKnobIncrement(iKnob, true);
-            } else if (value == KNOB_DECREMENT || value == KNOB_DECREMENT_FAST || value == KNOB_DECREMENT_VERYFAST) {
-              this.deviceListener.onKnobIncrement(iKnob, false);
-            } else {
-              // Knob sent absolute values but software is expecting relative values
-              LXMidiEngine.error("MFT Encoder MIDI Type should be ENC 3FH/41H for encoder " + number + ". Received value " + value);
-              // Let it through just to be nice
-              this.deviceListener.onKnob(iKnob, cc.getNormalized());
-            }
+          if (value == KNOB_INCREMENT || value == KNOB_INCREMENT_FAST || value == KNOB_INCREMENT_VERYFAST) {
+            this.deviceListener.onKnobIncrement(iKnob, true);
+          } else if (value == KNOB_DECREMENT || value == KNOB_DECREMENT_FAST || value == KNOB_DECREMENT_VERYFAST) {
+            this.deviceListener.onKnobIncrement(iKnob, false);
           } else {
+            // Knob sent absolute values but software is expecting relative values
+            LXMidiEngine.error("MFT Encoder MIDI Type should be ENC 3FH/41H for encoder " + number + ". Received value " + value);
+            // Let it through just to be nice
             this.deviceListener.onKnob(iKnob, cc.getNormalized());
           }
           return;

--- a/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
+++ b/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
@@ -64,7 +64,6 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
     super(label, value);
     setRange(min, max);
     setUnits(LXParameter.Units.INTEGER);
-    setWrap(true);
   }
 
   /**

--- a/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
+++ b/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
@@ -31,6 +31,13 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
 
   private String[] options = null;
 
+  public enum IncrementMode {
+    NORMALIZED,
+    RELATIVE
+  }
+
+  private IncrementMode incrementMode = IncrementMode.NORMALIZED;
+
   /**
    * Parameter with values from [0, range-1], 0 by default
    *
@@ -236,6 +243,15 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
       --value;
     }
     setValue(this.minValue + value);
+    return this;
+  }
+
+  public IncrementMode getIncrementMode() {
+    return this.incrementMode;
+  }
+
+  public DiscreteParameter setIncrementMode(IncrementMode incrementMode) {
+    this.incrementMode = incrementMode;
     return this;
   }
 

--- a/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
+++ b/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
@@ -177,7 +177,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter increment() {
-    return increment(1, isWrap());
+    return increment(1, isWrappable());
   }
 
   public DiscreteParameter increment(boolean wrap) {
@@ -185,7 +185,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter increment(int amt) {
-    return increment(amt, isWrap());
+    return increment(amt, isWrappable());
   }
 
   public DiscreteParameter increment(int amt, boolean wrap) {
@@ -198,7 +198,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter decrement() {
-    return decrement(1, isWrap());
+    return decrement(1, isWrappable());
   }
 
   public DiscreteParameter decrement(boolean wrap) {
@@ -206,7 +206,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter decrement(int amt) {
-    return decrement(amt, isWrap());
+    return decrement(amt, isWrappable());
   }
 
   public DiscreteParameter decrement(int amt, boolean wrap) {

--- a/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
+++ b/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
@@ -64,6 +64,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
     super(label, value);
     setRange(min, max);
     setUnits(LXParameter.Units.INTEGER);
+    setWrap(true);
   }
 
   /**
@@ -177,7 +178,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter increment() {
-    return increment(1, true);
+    return increment(1, isWrap());
   }
 
   public DiscreteParameter increment(boolean wrap) {
@@ -185,7 +186,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter increment(int amt) {
-    return increment(amt, true);
+    return increment(amt, isWrap());
   }
 
   public DiscreteParameter increment(int amt, boolean wrap) {
@@ -198,7 +199,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter decrement() {
-    return decrement(1, true);
+    return decrement(1, isWrap());
   }
 
   public DiscreteParameter decrement(boolean wrap) {
@@ -206,7 +207,7 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public DiscreteParameter decrement(int amt) {
-    return decrement(amt, true);
+    return decrement(amt, isWrap());
   }
 
   public DiscreteParameter decrement(int amt, boolean wrap) {

--- a/src/main/java/heronarts/lx/parameter/LXListenableNormalizedParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXListenableNormalizedParameter.java
@@ -29,6 +29,7 @@ public abstract class LXListenableNormalizedParameter extends
 
   private double exponent = 1;
   private boolean mappable = true;
+  private boolean allowWrap = false;
 
   protected LXListenableNormalizedParameter(String label, double value) {
     super(label, value);
@@ -55,6 +56,32 @@ public abstract class LXListenableNormalizedParameter extends
   @Override
   public boolean isMappable() {
     return this.mappable;
+  }
+
+  public boolean isWrap() {
+    return this.allowWrap;
+  }
+
+  public LXListenableNormalizedParameter setWrap(boolean allowWrap) {
+    this.allowWrap = allowWrap;
+    return this;
+  }
+
+  public LXListenableNormalizedParameter incrementNormalized(double amount) {
+    return incrementNormalized(amount, this.allowWrap);
+  }
+
+  public LXListenableNormalizedParameter incrementNormalized(double amount, boolean wrap) {
+    double normalized = this.getNormalized() + amount;
+    if (wrap) {
+      while (normalized > 1) {
+        normalized -= 1;
+      }
+      while (normalized < 0) {
+        normalized += 1;
+      }
+    }
+    return (LXListenableNormalizedParameter)this.setNormalized(normalized);
   }
 
 }

--- a/src/main/java/heronarts/lx/parameter/LXListenableNormalizedParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXListenableNormalizedParameter.java
@@ -29,7 +29,7 @@ public abstract class LXListenableNormalizedParameter extends
 
   private double exponent = 1;
   private boolean mappable = true;
-  private boolean allowWrap = false;
+  private boolean wrappable = false;
 
   protected LXListenableNormalizedParameter(String label, double value) {
     super(label, value);
@@ -58,17 +58,18 @@ public abstract class LXListenableNormalizedParameter extends
     return this.mappable;
   }
 
-  public boolean isWrap() {
-    return this.allowWrap;
-  }
-
-  public LXListenableNormalizedParameter setWrap(boolean allowWrap) {
-    this.allowWrap = allowWrap;
+  public LXListenableNormalizedParameter setWrappable(boolean wrappable) {
+    this.wrappable = wrappable;
     return this;
   }
 
+  @Override
+  public boolean isWrappable() {
+    return this.wrappable;
+  }
+
   public LXListenableNormalizedParameter incrementNormalized(double amount) {
-    return incrementNormalized(amount, this.allowWrap);
+    return incrementNormalized(amount, this.wrappable);
   }
 
   public LXListenableNormalizedParameter incrementNormalized(double amount, boolean wrap) {

--- a/src/main/java/heronarts/lx/parameter/LXNormalizedParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXNormalizedParameter.java
@@ -60,4 +60,14 @@ public interface LXNormalizedParameter extends LXParameter {
     return 1;
   }
 
+  /**
+   * Whether this parameter should wrap when incremented or decremented
+   * at the extent of its range.
+   *
+   * @return <code>true</code> if wrappable, false if otherwise
+   */
+  default public boolean isWrappable() {
+    return false;
+  }
+
 }

--- a/src/main/java/heronarts/lx/parameter/ObjectParameter.java
+++ b/src/main/java/heronarts/lx/parameter/ObjectParameter.java
@@ -26,6 +26,7 @@ public class ObjectParameter<T> extends DiscreteParameter {
     super(label, 0, objects.length);
     setObjects(objects);
     setIncrementMode(IncrementMode.RELATIVE);
+    setWrappable(true);
   }
 
   public ObjectParameter(String label, T[] objects, T value) {

--- a/src/main/java/heronarts/lx/parameter/ObjectParameter.java
+++ b/src/main/java/heronarts/lx/parameter/ObjectParameter.java
@@ -25,6 +25,7 @@ public class ObjectParameter<T> extends DiscreteParameter {
   public ObjectParameter(String label, T[] objects) {
     super(label, 0, objects.length);
     setObjects(objects);
+    setIncrementMode(IncrementMode.RELATIVE);
   }
 
   public ObjectParameter(String label, T[] objects, T value) {


### PR DESCRIPTION
The MFT can be configured to send increase/decrease MIDI CCs on knob rotation instead of absolute (0-127) position.  I think this is a preferable setting for use with LX.  It avoids an annoying MFT firmware limitation where the hardware device always sets the encoder level indicators when using absolute position.  This makes it impossible to see on the MFT when a discreteParameter has incremented to a new value.  With the knobs sending relative CCs ("ENC 3FH/41H" midi type) the indicator levels are set only by returning MIDI which retains more control from LX.

This also opens up the possibility of wrappable parameters which is super useful for things like hue or degrees of rotation.  A parameter can be made wrappable like this:
public final CompoundParameter angle = 
    (CompoundParameter) new CompoundParameter("Angle", .5, 0, 1)
    .setWrap(true);

I added some methods for wrap and incrementNormalized() for use by the MFT but not sure if LXListenableNormalizedParameter is the right home for them.  They're mainly for BoundedParameter and DiscreteParameter which are some but not all of the subclasses of LXListenableNormalizedParameter.

DiscreteParameters are now incremented/decremented by the MFT with a fixed amount of knob rotation regardless of the number of items in the list.  From my perspective this is a preferred behavior; it felt inconsistent when Enum(30 items) and Enum(4 items) required different amounts of rotation to increment one item a list.  However if someone is using DiscreteParameters with 100+ values this might not be the desired behavior.