### PR TITLE
Improve cue control on APC40mkII

### DIFF
--- a/src/main/java/heronarts/lx/mixer/LXMixerEngine.java
+++ b/src/main/java/heronarts/lx/mixer/LXMixerEngine.java
@@ -786,6 +786,18 @@ public class LXMixerEngine extends LXComponent implements LXOscComponent {
     }
   }
 
+  public LXMixerEngine enableChannelCue(LXAbstractChannel channel, boolean isExclusive) {
+    channel.cueActive.setValue(true);
+    if (isExclusive) {
+      for (LXAbstractChannel c : getChannels()) {
+        if (channel != c) {
+          c.cueActive.setValue(false);
+        }
+      }
+    }
+    return this;
+  }
+
   private class BlendStack {
 
     private int[] destination;


### PR DESCRIPTION
As discussed, except added a flag to track a fork in behavior.  For the first button press down, if the cue was active, it could be an un-cue or the start of a multi-cue.  For the start of the multi-cue, it feels right to be able to start with an already cued channel and add other ones to it.  So for a single button press on an active cue, the un-cue doesn't happen until button up.  Tested, seems logical on the board.

Happy to rename that variable - left it verbose so the behavior was obvious.