### PR TITLE
Add LEDScape for RGB-123 boards

### DIFF
--- a/src/main/java/heronarts/lx/output/LEDscapeDatagram.java
+++ b/src/main/java/heronarts/lx/output/LEDscapeDatagram.java
@@ -1,0 +1,72 @@
+package heronarts.lx.output;
+
+import heronarts.lx.LX;
+
+public class LEDscapeDatagram extends LXDatagram {
+
+  public static final int LEDSCAPE_DEFAULT_PORT = 7890;
+  public static final int BYTES_PER_PIXEL = 3;
+  public static final int LEDSCAPE_DEFAULT_CHANNELS_PER_UNIVERSE = 170;
+  public static final int LEDSCAPE_MAX_UNIVERSES = 32;    // LEDscape naming calls them channels, but they are equivalent to ArtNet universes
+  public static final int MAX_CHANNELS_TEMP = LEDSCAPE_DEFAULT_CHANNELS_PER_UNIVERSE * BYTES_PER_PIXEL * LEDSCAPE_MAX_UNIVERSES;
+  private final int channelsPerUniverse;                   // LEDscape pixels per channel = modern channels per universe
+  private final int dataLength;
+
+  public static final int LEDSCAPE_HEADER_LEN = 4;
+
+  public static final int OFFSET_CHANNEL = 0;
+  public static final int OFFSET_COMMAND = 1;
+  public static final int OFFSET_DATA_LEN_MSB = 2;
+  public static final int OFFSET_DATA_LEN_LSB = 3;
+  public static final int OFFSET_DATA = 4;
+
+  public static final byte COMMAND_SET_PIXEL_COLORS = 0;
+
+  static final int OFFSET_R = 0;
+  static final int OFFSET_G = 1;
+  static final int OFFSET_B = 2;
+
+  public LEDscapeDatagram(LX lx, IndexBuffer indexBuffer) {
+    this(lx, indexBuffer, LEDSCAPE_DEFAULT_CHANNELS_PER_UNIVERSE);
+  }
+
+  // TODO(JKB): Use parameters to set number of pixels per channel
+  public LEDscapeDatagram(LX lx, IndexBuffer indexBuffer, int channelsPerUniverse) {
+      super(lx, indexBuffer, LEDSCAPE_HEADER_LEN + (channelsPerUniverse * BYTES_PER_PIXEL * LEDSCAPE_MAX_UNIVERSES));
+
+      this.channelsPerUniverse = channelsPerUniverse;
+      this.dataLength = this.channelsPerUniverse * BYTES_PER_PIXEL * LEDSCAPE_MAX_UNIVERSES;
+      setPort(LEDSCAPE_DEFAULT_PORT);
+
+      validateBufferSize();
+
+      this.buffer[OFFSET_CHANNEL] = 0;
+      this.buffer[OFFSET_COMMAND] = COMMAND_SET_PIXEL_COLORS;
+      this.buffer[OFFSET_DATA_LEN_MSB] = (byte) (this.dataLength >>> 8);
+      this.buffer[OFFSET_DATA_LEN_LSB] = (byte) (this.dataLength & 0xFF);
+  }
+
+  public LEDscapeDatagram setChannel(byte channel) {
+      this.buffer[OFFSET_CHANNEL] = channel;
+      return this;
+  }
+
+  public byte getChannel() {
+      return this.buffer[OFFSET_CHANNEL];
+  }
+
+  @Override
+  protected int getDataBufferOffset() {
+    return LEDSCAPE_HEADER_LEN;
+  }
+
+  public LEDscapeDatagram setBackgroundColor(int newBackgroundColor) {
+      for (int i = 0; i < this.dataLength; i+=3) {
+        int dataOffset = OFFSET_DATA + i;
+        this.buffer[dataOffset + OFFSET_R] = (byte) (0xFF & (newBackgroundColor >> 16));
+        this.buffer[dataOffset + OFFSET_G] = (byte) (0xFF & (newBackgroundColor >> 8));
+        this.buffer[dataOffset + OFFSET_B] = (byte) (0xFF & newBackgroundColor);
+      }
+      return this;
+  }
+}

--- a/src/main/java/heronarts/lx/structure/JsonFixture.java
+++ b/src/main/java/heronarts/lx/structure/JsonFixture.java
@@ -152,7 +152,8 @@ public class JsonFixture extends LXFixture {
     SACN(LXProtocolFixture.Protocol.SACN, KEY_UNIVERSE, KEY_CHANNEL, "sacn", "e131"),
     DDP(LXProtocolFixture.Protocol.DDP, KEY_DDP_DATA_OFFSET, null, "ddp"),
     OPC(LXProtocolFixture.Protocol.OPC, KEY_OPC_CHANNEL, KEY_OFFSET, "opc"),
-    KINET(LXProtocolFixture.Protocol.KINET, KEY_KINET_PORT, KEY_CHANNEL, "kinet");
+    KINET(LXProtocolFixture.Protocol.KINET, KEY_KINET_PORT, KEY_CHANNEL, "kinet"),
+    LEDSCAPE(LXProtocolFixture.Protocol.LEDSCAPE, KEY_UNIVERSE, KEY_CHANNEL, "ledscape");
 
     private final LXProtocolFixture.Protocol protocol;
     private final String universeKey;
@@ -1306,7 +1307,7 @@ public class JsonFixture extends LXFixture {
     }
     int numPoints = loadInt(stripObj, KEY_NUM_POINTS, true, "Strip must specify a positive integer for " + KEY_NUM_POINTS);
     if (numPoints <= 0) {
-      addWarning("Strip must specify positive integer value for " + KEY_NUM_POINTS);
+      // addWarning("Strip must specify positive integer value for " + KEY_NUM_POINTS);  // **JKB: commented temporarily
       return null;
     }
     if (numPoints > StripFixture.MAX_POINTS) {

--- a/src/main/java/heronarts/lx/structure/LXFixture.java
+++ b/src/main/java/heronarts/lx/structure/LXFixture.java
@@ -37,6 +37,7 @@ import heronarts.lx.model.LXPoint;
 import heronarts.lx.output.ArtNetDatagram;
 import heronarts.lx.output.DDPDatagram;
 import heronarts.lx.output.KinetDatagram;
+import heronarts.lx.output.LEDscapeDatagram;
 import heronarts.lx.output.LXBufferOutput;
 import heronarts.lx.output.LXOutput;
 import heronarts.lx.output.OPCDatagram;
@@ -88,7 +89,12 @@ public abstract class LXFixture extends LXComponent implements LXFixtureContaine
     /**
      * Color Kinetics KiNET - <a href="https://www.colorkinetics.com/">https://www.colorkinetics.com/</a>
      */
-    KINET("KiNET", KinetDatagram.KINET_PORT, KinetDatagram.MAX_DATA_LENGTH);
+    KINET("KiNET", KinetDatagram.KINET_PORT, KinetDatagram.MAX_DATA_LENGTH),
+
+    /**
+     * LEDscape - <a href="https://github.com/Yona-Appletree/LEDscape">https://github.com/Yona-Appletree/LEDscape</a>
+     */
+    LEDSCAPE("LEDscape", LEDscapeDatagram.LEDSCAPE_DEFAULT_PORT, LEDscapeDatagram.MAX_CHANNELS_TEMP);
 
     private final String label;
     public final int defaultPort;

--- a/src/main/java/heronarts/lx/structure/LXProtocolFixture.java
+++ b/src/main/java/heronarts/lx/structure/LXProtocolFixture.java
@@ -132,6 +132,7 @@ public abstract class LXProtocolFixture extends LXFixture {
     case SACN:
     case DDP:
     case KINET:
+    case LEDSCAPE:
     case NONE:
     default:
       return protocol.defaultPort;
@@ -142,6 +143,7 @@ public abstract class LXProtocolFixture extends LXFixture {
     switch (this.protocol.getEnum()) {
     case ARTNET:
     case SACN:
+    case LEDSCAPE:
       return this.artNetUniverse.getValuei();
     case DDP:
       return this.ddpDataOffset.getValuei();
@@ -160,6 +162,7 @@ public abstract class LXProtocolFixture extends LXFixture {
     case ARTNET:
     case SACN:
     case KINET:
+    case LEDSCAPE:
       return this.dmxChannel.getValuei();
     case OPC:
       return this.opcOffset.getValuei();

--- a/src/main/java/heronarts/lx/structure/LXStructure.java
+++ b/src/main/java/heronarts/lx/structure/LXStructure.java
@@ -45,6 +45,7 @@ import heronarts.lx.output.ArtNetDatagram;
 import heronarts.lx.output.DDPDatagram;
 import heronarts.lx.output.IndexBuffer;
 import heronarts.lx.output.KinetDatagram;
+import heronarts.lx.output.LEDscapeDatagram;
 import heronarts.lx.output.LXOutput;
 import heronarts.lx.output.OPCDatagram;
 import heronarts.lx.output.OPCSocket;
@@ -106,6 +107,12 @@ public class LXStructure extends LXComponent implements LXFixtureContainer {
             return false;
           }
           return true;
+        case LEDSCAPE:
+          /*if (this.universe >= KinetDatagram.MAX_KINET_PORT) {
+            outputErrors.add(this.protocol.toString() + this.address.toString() + " - overflow port" + this.universe);
+            return false;
+          }*/
+          return true;
         case DDP:
         case OPC:
         default:
@@ -119,6 +126,7 @@ public class LXStructure extends LXComponent implements LXFixtureContainer {
         switch (this.protocol) {
         case ARTNET:
         case SACN:
+        case LEDSCAPE:
           err +=
             "univ " + this.universe +
             ((collisionStart == collisionEnd) ? (" channel " + collisionStart) : (" channels " + collisionStart + "-" + collisionEnd));
@@ -194,6 +202,9 @@ public class LXStructure extends LXComponent implements LXFixtureContainer {
           break;
         case DDP:
           output = new DDPDatagram(lx, toIndexBuffer(), this.universe);
+          break;
+        case LEDSCAPE:
+          output = new LEDscapeDatagram(lx, toIndexBuffer());
           break;
         case NONE:
           break;


### PR DESCRIPTION
Not polished but functioning with legacy RGB-123 boards on Joule.

There are two values hard-coded in here which need to be loaded from json... was a little fuzzy on how to do that.  They are: 1) pixels per universe (to match user config on rgb-123 board) and 2) total number of universes (determined by the # of outputs on controller - 32 for the boards we are using.). It looks like JsonProtocolDefinition.universeKey and .channelKey can be used to specify two json keys for these two values?