### PR TITLE
Use midi sysex to apply lx-friendly config to MFT

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -745,7 +745,6 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
         } else {
           sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, RGB_ANIMATION_NONE);
           sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_ANIMATION_NONE);
-          sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_BRIGHTNESS_OFF);
           sendControlChange(CHANNEL_ANIMATIONS_AND_BRIGHTNESS, DEVICE_KNOB + i, INDICATOR_BRIGHTNESS_25);
           if (i <= lxConfig.encoders.length && lxConfig.encoders[i].has_detent.value == CFG_TRUE) {
             sendControlChange(CHANNEL_ROTARY_ENCODER, DEVICE_KNOB+i, 63);


### PR DESCRIPTION
Tested and working on my MFT.  Have not yet tested with more than one MFT attached to system.

Currently:
-Sets global settings and encoder settings on initialization
-Sends updated encoder settings on device change (currently the only configuration adjusted is Detent aka Bipolar)

Structure is in place to save current MFT config so it can be cleanly re-applied at shutdown.  Need a sysex call/response mechanism to pull current values.

Unfortunately - at the last minute discovered that when the MFT receives an encoder config it disables the display, as the firmware only anticipated receiving encoder updates in combination with a full system config update.  From my initial look at the firmware it appears the only method of re-enabling the display is to send global settings and trigger a reboot, which adds reboot lag plus startup animation lag.  We'll have to decide if the lag is too inconvenient to be worth updating the encoder detent setting on target device changes.  Note I set it up to avoid rebooting if no knob detent settings are changed, so a reboot doesn't happen if you bounce around between patterns with either no bipolar parameters or the same alignment of bipolar parameters.  (In my case - I use a common base class for patterns so the alignment of bipolar parameters is usually the same).
