### PR TITLE
Clean up MFT behavior for stray encoder readings

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -764,13 +764,6 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       }
     }
 
-    @SuppressWarnings("unused")
-    private void onKnob(int index, double normalized) {
-      if (this.knobs[index] != null) {
-        this.knobs[index].setNormalized(normalized);
-      }
-    }
-
     private final static double KNOB_INCREMENT_AMOUNT = 1/128.;
 
     private void onKnobIncrement(int index, boolean isUp) {
@@ -1010,19 +1003,22 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       case CHANNEL_ROTARY_ENCODER:
         if (number >= DEVICE_KNOB && number <= DEVICE_KNOB_MAX) {
           int iKnob = number - DEVICE_KNOB;
-          if (value < KNOB_DECREMENT_VERYFAST || value > KNOB_INCREMENT_VERYFAST) {
+          if (value == KNOB_INCREMENT || value == KNOB_INCREMENT_FAST || value == KNOB_INCREMENT_VERYFAST) {
+            this.deviceListener.onKnobIncrement(iKnob, true);
+          } else if (value == KNOB_DECREMENT || value == KNOB_DECREMENT_FAST || value == KNOB_DECREMENT_VERYFAST) {
+            this.deviceListener.onKnobIncrement(iKnob, false);
+          } else {
             // Knob sent value outside of expected range for relative values.  Possible causes:
             //   1. Knob is configured to send absolute values.
             //   2. Knob was rotated during config sysex / reboot.
             //   3. Knob internals are dusty.
             LXMidiEngine.error("Received value " + value + " on MFT encoder " + number + ". Confirm Encoder MIDI Type is ENC 3FH/41H and controller is clean.");
             // Assume the direction is correct, keep behavior smooth even on dusty controllers.
-            value = LXUtils.constrain(value, KNOB_DECREMENT_VERYFAST, KNOB_INCREMENT_VERYFAST);
-          }
-          if (value == KNOB_INCREMENT || value == KNOB_INCREMENT_FAST || value == KNOB_INCREMENT_VERYFAST) {
-            this.deviceListener.onKnobIncrement(iKnob, true);
-          } else if (value == KNOB_DECREMENT || value == KNOB_DECREMENT_FAST || value == KNOB_DECREMENT_VERYFAST) {
-            this.deviceListener.onKnobIncrement(iKnob, false);
+            if (value > KNOB_INCREMENT_VERYFAST) {
+              this.deviceListener.onKnobIncrement(iKnob, true);
+            } else if (value < KNOB_DECREMENT_VERYFAST) {
+              this.deviceListener.onKnobIncrement(iKnob, false);
+            }
           }
           return;
         }


### PR DESCRIPTION
Found two use cases where MFT encoder sends a value outside of previously expected range:
1. Knob is rotated during config sysex / reboot cycle.
2. After two dusty events last summer, parameters were occasionally jumpy on MFT knob turn even when configured correctly (sending relative values).  Current theory is dust in the internals causes a jump in the reading which is interpreted as an extremely fast increment/decrement.

Previous behavior was values fall through and get interpreted as absolute.  This causes a harsh parameter jump and visual glitch which is undesired.

This PR constrains encoder inputs to expected range to avoid unwanted behavior on a dusty system.  If it appears after further field use that some of these values are on the wrong side of the expected range, then will have to adjust this code to discard the values completely.