### PR TITLE
Fix bug: MFT normalized value not reaching 1 for DiscreteParameter

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -695,7 +695,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
             // We will track an absolute knob value for Normalized DiscreteParameters even though MFT sends relative CCs.
             if (parameter instanceof DiscreteParameter && ((DiscreteParameter)parameter).getIncrementMode() == IncrementMode.NORMALIZED) {
               this.knobTicks[i] = (int) (parameter.getNormalized() * 127);
-              this.knobIncrementSize[i] = LXUtils.max(1, 128/((DiscreteParameter)parameter).getRange());
+              this.knobIncrementSize[i] = LXUtils.max(1, 127/((DiscreteParameter)parameter).getRange());
             }
             if (!uniqueParameters.contains(parameter)) {
               parameter.addListener(this);
@@ -764,7 +764,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
       }
     }
 
-    private final static double KNOB_INCREMENT_AMOUNT = 1/128.;
+    private final static double KNOB_INCREMENT_AMOUNT = 1/127.;
 
     private void onKnobIncrement(int index, boolean isUp) {
       LXListenableNormalizedParameter knob = this.knobs[index];
@@ -783,7 +783,7 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
               value = LXUtils.constrain(value, 0, 127);
               this.knobTicks[index] = value;
             }
-            knob.setNormalized(value/128.);
+            knob.setNormalized(value/127.);
           } else {
             // IncrementMode == RELATIVE
             // Move after a set number of ticks in the same direction


### PR DESCRIPTION
Need another set of eyes on this.  The problem shows up with a high resolution DiscreteParameter, say range 0-255, IncrementMode=NORMALIZED.  Easier to see if not wrappable.

In `onKnobIncrement(..)`, value was being constrained to (0,127) prior to calling `knob.setNormalized(value/128.)`.  So the value of 1 was never passed to setNormalized() and the max value of the parameter could not be reached by turning the MFT knob.

127 is a max value imposed by the definition of midi CC (0-127).  I think this means the number of increments on a midi knob between min and max, inclusive, is 127.  It's only 128 including the full wrap.  I changed the 128s to 127s in the code, which seems right at the moment but needs double checking.