### PR TITLE
Improve handling of black color by gradients and palette transitions

### DIFF
--- a/src/main/java/heronarts/lx/color/ColorParameter.java
+++ b/src/main/java/heronarts/lx/color/ColorParameter.java
@@ -109,6 +109,10 @@ public class ColorParameter extends AggregateParameter {
     return this;
   }
 
+  public boolean isBlack() {
+    return this.brightness.getValue() == 0;
+  }
+
   public String getHexString() {
     return String.format("0x%08x", this.color);
   }

--- a/src/main/java/heronarts/lx/color/GradientUtils.java
+++ b/src/main/java/heronarts/lx/color/GradientUtils.java
@@ -206,11 +206,9 @@ public class GradientUtils {
       if (c1.isBlack()) {
         hue1 = hue2;
         sat1 = 0;
-        bright1 = 0;
       } else if (c2.isBlack()) {
         hue2 = hue1;
         sat2 = 0;
-        bright2 = 0;
       }
       return LXColor.hsb(
         LXUtils.lerpf(hue1, hue2, lerp),
@@ -234,11 +232,9 @@ public class GradientUtils {
       if (c1.isBlack()) {
         hue1 = hue2;
         sat1 = 0;
-        bright1 = 0;
       } else if (c2.isBlack()) {
         hue2 = hue1;
         sat2 = 0;
-        bright2 = 0;
       }
       return LXColor.hsb(
         LXUtils.lerpf(hue1, hue2, lerp),

--- a/src/main/java/heronarts/lx/color/GradientUtils.java
+++ b/src/main/java/heronarts/lx/color/GradientUtils.java
@@ -136,6 +136,10 @@ public class GradientUtils {
       this.b = that.b;
     }
 
+    public boolean isBlack() {
+      return this.brightness == 0;
+    }
+
     @Override
     public String toString() {
       return String.format("rgb(%d,%d,%d) hsb(%f,%f,%f)", r, g, b, hue, saturation, brightness);
@@ -193,25 +197,53 @@ public class GradientUtils {
     }),
 
     HSV((c1, c2, lerp) -> {
+      float hue1 = c1.hue;
+      float hue2 = c2.hue;
+      float sat1 = c1.saturation;
+      float sat2 = c2.saturation;
+      float bright1 = c1.brightness;
+      float bright2 = c2.brightness;
+      if (c1.isBlack()) {
+        hue1 = hue2;
+        sat1 = 0;
+        bright1 = 0;
+      } else if (c2.isBlack()) {
+        hue2 = hue1;
+        sat2 = 0;
+        bright2 = 0;
+      }
       return LXColor.hsb(
-        LXUtils.lerpf(c1.hue, c2.hue, lerp),
-        LXUtils.lerpf(c1.saturation, c2.saturation, lerp),
-        LXUtils.lerpf(c1.brightness, c2.brightness, lerp)
+        LXUtils.lerpf(hue1, hue2, lerp),
+        LXUtils.lerpf(sat1, sat2, lerp),
+        LXUtils.lerpf(bright1, bright2, lerp)
       );
     }),
 
     HSV2((c1, c2, lerp) -> {
       float hue1 = c1.hue;
       float hue2 = c2.hue;
+      float sat1 = c1.saturation;
+      float sat2 = c2.saturation;
+      float bright1 = c1.brightness;
+      float bright2 = c2.brightness;
       if (hue2 - hue1 > 180) {
         hue1 += 360;
       } else if (hue1 - hue2 > 180) {
         hue2 += 360;
       }
+      if (c1.isBlack()) {
+        hue1 = hue2;
+        sat1 = 0;
+        bright1 = 0;
+      } else if (c2.isBlack()) {
+        hue2 = hue1;
+        sat2 = 0;
+        bright2 = 0;
+      }
       return LXColor.hsb(
         LXUtils.lerpf(hue1, hue2, lerp),
-        LXUtils.lerpf(c1.saturation, c2.saturation, lerp),
-        LXUtils.lerpf(c1.brightness, c2.brightness, lerp)
+        LXUtils.lerpf(sat1, sat2, lerp),
+        LXUtils.lerpf(bright1, bright2, lerp)
       );
     });
 

--- a/src/main/java/heronarts/lx/color/GradientUtils.java
+++ b/src/main/java/heronarts/lx/color/GradientUtils.java
@@ -201,19 +201,17 @@ public class GradientUtils {
       float hue2 = c2.hue;
       float sat1 = c1.saturation;
       float sat2 = c2.saturation;
-      float bright1 = c1.brightness;
-      float bright2 = c2.brightness;
       if (c1.isBlack()) {
         hue1 = hue2;
-        sat1 = 0;
+        sat1 = sat2;
       } else if (c2.isBlack()) {
         hue2 = hue1;
-        sat2 = 0;
+        sat2 = sat1;
       }
       return LXColor.hsb(
         LXUtils.lerpf(hue1, hue2, lerp),
         LXUtils.lerpf(sat1, sat2, lerp),
-        LXUtils.lerpf(bright1, bright2, lerp)
+        LXUtils.lerpf(c1.brightness, c2.brightness, lerp)
       );
     }),
 
@@ -222,8 +220,6 @@ public class GradientUtils {
       float hue2 = c2.hue;
       float sat1 = c1.saturation;
       float sat2 = c2.saturation;
-      float bright1 = c1.brightness;
-      float bright2 = c2.brightness;
       if (hue2 - hue1 > 180) {
         hue1 += 360;
       } else if (hue1 - hue2 > 180) {
@@ -231,15 +227,15 @@ public class GradientUtils {
       }
       if (c1.isBlack()) {
         hue1 = hue2;
-        sat1 = 0;
+        sat1 = sat2;
       } else if (c2.isBlack()) {
         hue2 = hue1;
-        sat2 = 0;
+        sat2 = sat1;
       }
       return LXColor.hsb(
         LXUtils.lerpf(hue1, hue2, lerp),
         LXUtils.lerpf(sat1, sat2, lerp),
-        LXUtils.lerpf(bright1, bright2, lerp)
+        LXUtils.lerpf(c1.brightness, c2.brightness, lerp)
       );
     });
 

--- a/src/main/java/heronarts/lx/color/LXPalette.java
+++ b/src/main/java/heronarts/lx/color/LXPalette.java
@@ -517,11 +517,9 @@ public class LXPalette extends LXComponent implements LXLoopTask, LXOscComponent
       if (isBlack(fromColor)) {
         fromHue = toHue;
         fromSat = 0;
-        fromBright = 0;
       } else if (isBlack(toColor)) {
         toHue = fromHue;
         toSat = 0;
-        toBright = 0;
       }
       color.primary.setColor(LXColor.hsb(
         LXUtils.lerpf(fromHue, toHue, lerp),

--- a/src/main/java/heronarts/lx/color/LXPalette.java
+++ b/src/main/java/heronarts/lx/color/LXPalette.java
@@ -505,15 +505,28 @@ public class LXPalette extends LXComponent implements LXLoopTask, LXOscComponent
     case HSV:
       float fromHue = fromColor.hue.getValuef();
       float toHue = toColor.hue.getValuef();
+      float fromSat = fromColor.saturation.getValuef();
+      float toSat = toColor.saturation.getValuef();
+      float fromBright = fromColor.brightness.getValuef();
+      float toBright = toColor.brightness.getValuef();
       if (toHue - fromHue > 180) {
         fromHue += 360;
       } else if (fromHue - toHue > 180) {
         toHue += 360;
       }
+      if (isBlack(fromColor)) {
+        fromHue = toHue;
+        fromSat = 0;
+        fromBright = 0;
+      } else if (isBlack(toColor)) {
+        toHue = fromHue;
+        toSat = 0;
+        toBright = 0;
+      }
       color.primary.setColor(LXColor.hsb(
         LXUtils.lerpf(fromHue, toHue, lerp),
-        LXUtils.lerpf(fromColor.saturation.getValuef(), toColor.saturation.getValuef(), lerp),
-        LXUtils.lerpf(fromColor.brightness.getValuef(), toColor.brightness.getValuef(), lerp)
+        LXUtils.lerpf(fromSat, toSat, lerp),
+        LXUtils.lerpf(fromBright, toBright, lerp)
       ));
       break;
 
@@ -526,6 +539,10 @@ public class LXPalette extends LXComponent implements LXLoopTask, LXOscComponent
       ));
       break;
     }
+  }
+
+  private boolean isBlack(ColorParameter color) {
+    return color.brightness.getValue() == 0;
   }
 
   /**

--- a/src/main/java/heronarts/lx/color/LXPalette.java
+++ b/src/main/java/heronarts/lx/color/LXPalette.java
@@ -507,24 +507,22 @@ public class LXPalette extends LXComponent implements LXLoopTask, LXOscComponent
       float toHue = toColor.hue.getValuef();
       float fromSat = fromColor.saturation.getValuef();
       float toSat = toColor.saturation.getValuef();
-      float fromBright = fromColor.brightness.getValuef();
-      float toBright = toColor.brightness.getValuef();
       if (toHue - fromHue > 180) {
         fromHue += 360;
       } else if (fromHue - toHue > 180) {
         toHue += 360;
       }
-      if (isBlack(fromColor)) {
+      if (fromColor.isBlack()) {
         fromHue = toHue;
-        fromSat = 0;
-      } else if (isBlack(toColor)) {
+        fromSat = toSat;
+      } else if (toColor.isBlack()) {
         toHue = fromHue;
-        toSat = 0;
+        toSat = fromSat;
       }
       color.primary.setColor(LXColor.hsb(
         LXUtils.lerpf(fromHue, toHue, lerp),
         LXUtils.lerpf(fromSat, toSat, lerp),
-        LXUtils.lerpf(fromBright, toBright, lerp)
+        LXUtils.lerpf(fromColor.brightness.getValuef(), toColor.brightness.getValuef(), lerp)
       ));
       break;
 
@@ -537,10 +535,6 @@ public class LXPalette extends LXComponent implements LXLoopTask, LXOscComponent
       ));
       break;
     }
-  }
-
-  private boolean isBlack(ColorParameter color) {
-    return color.brightness.getValue() == 0;
   }
 
   /**


### PR DESCRIPTION
Attempting to improve an issue with gradients pointed out by @jvyduna.

To reproduce:
- Set the master swatch: first color to hsb(60,100,100)(yellow) and the second color to hsb(210,100,0)(black, visually)
- Add a Gradient pattern: set to HSV2, Palette, and 2 Stops.
- The generated gradient goes yellow->green->black.
The issue is that a color set to black in the UI is still backed by hue & saturation values. Even LXColor.BLACK has an internal hue value of 0 which is red.  Setting hue of the black color2 to equal hue of color1 doesn't fix the problem if color1 has an oscillating hue.

This PR produces expected behavior for the Gradient pattern and also palette transitions.  It treats a color with zero brightness as hsb(other color's hue, 0, 0) in the blends.

Will not be surprise if this is constrained by other things.  Although creating a gradient out of black seems like a common enough case to deserve improvement.