### PR TITLE
Allow public send of OSC string arguments

### DIFF
--- a/src/main/java/heronarts/lx/osc/LXOscEngine.java
+++ b/src/main/java/heronarts/lx/osc/LXOscEngine.java
@@ -267,6 +267,13 @@ public class LXOscEngine extends LXComponent {
     return this;
   }
 
+  public LXOscEngine sendMessage(String path, String value) {
+    if (this.engineTransmitter != null) {
+      this.engineTransmitter.sendMessage(path, value);
+    }
+    return this;
+  }
+
   public LXOscEngine sendParameter(LXParameter parameter) {
     if (this.engineTransmitter != null) {
       this.engineTransmitter.onParameterChanged(parameter);
@@ -430,6 +437,14 @@ public class LXOscEngine extends LXComponent {
       oscMessage.setAddressPattern(address);
       oscFloat.setValue(value);
       oscMessage.add(oscFloat);
+      sendMessage(oscMessage);
+    }
+
+    private void sendMessage(String address, String value) {
+      oscMessage.clearArguments();
+      oscMessage.setAddressPattern(address);
+      oscString.setValue(value);
+      oscMessage.add(oscString);
       sendMessage(oscMessage);
     }
 


### PR DESCRIPTION
Looks like the `String` pass-through methods were missing.  Matches existing `float` and `int` methods.