### PR TITLE
Fix Maven build out of box by avoiding error on JAVA_HOME

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,15 +75,6 @@
 	<build>
 		<plugins>
 			<plugin>
-			    <groupId>org.apache.maven.plugins</groupId>
-			    <artifactId>maven-javadoc-plugin</artifactId>
-			    <version>3.0.1</version>
-			    <configuration>
-			        <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
-			    </configuration>
-			</plugin>
-
-			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven-compiler-plugin.version}</version>
@@ -151,6 +142,7 @@
 							<location>../../build/gson</location>
 						</offlineLink>
 					</offlineLinks>
+					<javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,15 @@
 	<build>
 		<plugins>
 			<plugin>
+			    <groupId>org.apache.maven.plugins</groupId>
+			    <artifactId>maven-javadoc-plugin</artifactId>
+			    <version>3.0.1</version>
+			    <configuration>
+			        <javadocExecutable>${java.home}/bin/javadoc</javadocExecutable>
+			    </configuration>
+			</plugin>
+
+			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>${maven-compiler-plugin.version}</version>


### PR DESCRIPTION
By default the dev toolchain produces an error running maven clean package within eclipse, on OSX/Ventura/apple arch:

`Error while generating Javadoc: Unable to find javadoc command: The environment variable JAVA_HOME is not correctly set.
`

JAVA_HOME is not set by the installers, but this addition to pom solves the problem.  Worth inclusion to make things build out of the box?