### PR TITLE
Return normalized value of zero for single-int DiscreteParameter

### DIFF
--- a/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
+++ b/src/main/java/heronarts/lx/parameter/DiscreteParameter.java
@@ -257,6 +257,9 @@ public class DiscreteParameter extends LXListenableNormalizedParameter {
   }
 
   public double getNormalized() {
+    if (this.range == 1) {
+      return 0;
+    }
     return (getValue() - this.minValue) / (this.range - 1);
   }
 


### PR DESCRIPTION
A DiscreteParameter can exist with a range of 1, ie a single value.  Calling getNormalized() on this parameter was returning NaN from the divide by zero.