### PR TITLE
Get DMX value as integer

### DIFF
--- a/src/main/java/heronarts/lx/dmx/LXDmxEngine.java
+++ b/src/main/java/heronarts/lx/dmx/LXDmxEngine.java
@@ -151,6 +151,10 @@ public class LXDmxEngine extends LXComponent {
     return this.data[universe][channel];
   }
 
+  public int getValuei(int universe, int channel) {
+    return this.data[universe][channel] & 0xff;
+  }
+
   public double getNormalized(int universe, int channel) {
     return (this.data[universe][channel] & 0xff) / 255.;
   }


### PR DESCRIPTION
For some consumers of DMX information it's useful to see the DMX value as an integer rather than a normalized value.