### PR TITLE
Add public accessor for AHDSREnvelope.stage

### DIFF
--- a/src/main/java/heronarts/lx/modulator/AHDSREnvelope.java
+++ b/src/main/java/heronarts/lx/modulator/AHDSREnvelope.java
@@ -284,6 +284,13 @@ public class AHDSREnvelope extends LXModulator implements LXNormalizedParameter 
     }
   }
 
+  /**
+   * Current stage of the envelope.
+   */
+  public Stage getStage() {
+    return this.stage;
+  }
+
   @Override
   public LXNormalizedParameter setNormalized(double value) {
     throw new UnsupportedOperationException("Cannot setNormalized on AHDSREnvelope");


### PR DESCRIPTION
I'm using an AHDSREnvelope from code.  It seems like I should be able to check the current stage with a `getStage()` method.  It would also be nice to listen for stage changes rather than poll them every frame.  Would you consider adding a Listener class to this modulator with a `stageChanged()` event?