### PR TITLE
Remove unique encoder click behavior for DiscreteParameter

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
+++ b/src/main/java/heronarts/lx/midi/surface/MidiFighterTwister.java
@@ -815,11 +815,6 @@ public class MidiFighterTwister extends LXMidiSurface implements LXMidiSurface.B
               bp.toggle();
             }
           }
-        } else if (p instanceof DiscreteParameter) {
-          // Enum,Integer,etc will be incremented on click
-          if (isPressed) {
-            ((DiscreteParameter)p).increment();
-          }
         } else {
           // Set other parameter types to default value on click
           if (isPressed) {


### PR DESCRIPTION
The click-to-increment DiscreteParameters was a nice idea but in practice I've found it to be annoying.  As a user you're expecting a certain behavior from the click (I'm expecting Reset) and it would be more convenient if the behavior was the same for DiscreteParameters.