### PR TITLE
Allow reset to new default value in StringParameter

### DIFF
--- a/src/main/java/heronarts/lx/parameter/StringParameter.java
+++ b/src/main/java/heronarts/lx/parameter/StringParameter.java
@@ -49,7 +49,7 @@ public class StringParameter extends LXListenableParameter {
 
   @Override
   public LXParameter reset(double value) {
-    throw new UnsupportedOperationException("StringParamater cannot be reset to a numeric value");
+    throw new UnsupportedOperationException("StringParameter cannot be reset to a numeric value");
   }
 
   public StringParameter reset(String string) {

--- a/src/main/java/heronarts/lx/parameter/StringParameter.java
+++ b/src/main/java/heronarts/lx/parameter/StringParameter.java
@@ -52,6 +52,11 @@ public class StringParameter extends LXListenableParameter {
     throw new UnsupportedOperationException("StringParamater cannot be reset to a numeric value");
   }
 
+  public StringParameter reset(String string) {
+    this.defaultString = string;
+    return setValue(this.defaultString);
+  }
+
   public StringParameter setValue(String string) {
     return setValue(string, false);
   }


### PR DESCRIPTION
StringParameter had no mechanism to modify the default value after the parameter was created.  Adding a `reset(new default)` method to match other parameter types.