### PR TITLE
Add channel banks and fader pickup to APCminiMk2

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APCminiMk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APCminiMk2.java
@@ -444,7 +444,7 @@ public class APCminiMk2 extends LXMidiSurface implements LXMidiSurface.Bidirecti
 
   }
 
-  private final MixerSurface mixerSurface;
+  protected final MixerSurface mixerSurface;
 
   private final MixerSurface.Listener mixerSurfaceListener = new MixerSurface.Listener() {
     @Override

--- a/src/main/java/heronarts/lx/midi/surface/MixerSurface.java
+++ b/src/main/java/heronarts/lx/midi/surface/MixerSurface.java
@@ -1,0 +1,227 @@
+/**
+ * Copyright 2024- Justin Belcher, Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ * @author Justin K. Belcher <justin@jkb.studio>
+ */
+
+package heronarts.lx.midi.surface;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import heronarts.lx.LX;
+import heronarts.lx.mixer.LXAbstractChannel;
+import heronarts.lx.mixer.LXMixerEngine;
+import heronarts.lx.utils.LXUtils;
+
+/**
+ * Utility class to access a fixed number of mixer channels.
+ * Adds channel banking and an option to hide channels.
+ */
+public class MixerSurface {
+
+  public interface Listener {
+    /**
+     * Selected bank has changed
+     */
+    public void onBankChanged(int bank);
+
+    /**
+     * The channel assigned to a surface position has changed.
+     * @param index Index relative to surface
+     * @param channel New channel value, could be null
+     * @param previousChannel Previous channel value, could be null
+     */
+    public void onChannelChanged(int index, LXAbstractChannel channel, LXAbstractChannel previousChannel);
+  }
+
+  private final Listener listener;
+  private final LX lx;
+  private final int bankSize;
+
+  private int bank = 0;
+
+  private final Map<LXAbstractChannel, Boolean> channelAllowance = new HashMap<LXAbstractChannel, Boolean>();
+  private final List<LXAbstractChannel> allowedChannels = new ArrayList<LXAbstractChannel>();
+  private final List<LXAbstractChannel> mutableChannels = new ArrayList<LXAbstractChannel>();
+  public final List<LXAbstractChannel> channels = Collections.unmodifiableList(this.mutableChannels);
+
+  public MixerSurface(LX lx, Listener listener, int bankSize) {
+    this.lx = lx;
+    this.listener = listener;
+    this.bankSize = bankSize;
+
+    for (int i = 0; i < this.bankSize; i++) {
+      this.mutableChannels.add(null);
+    }
+  }
+
+  /**
+   * Child class may hide channels by returning false to this method.
+   * Method will be called once per channel.
+   */
+  public boolean isChannelAllowed(LXAbstractChannel channel) {
+    return true;
+  }
+
+  public void setChannelAllowed(LXAbstractChannel channel, boolean allowed) {
+    if (!this.channelAllowance.containsKey(channel)) {
+      throw new IllegalArgumentException("Channel unknown by MixerSurface");
+    }
+
+    if (this.channelAllowance.get(channel) != allowed) {
+      this.channelAllowance.put(channel, allowed);
+      refreshAllowedChannels();
+    }
+  }
+
+  private int getIndexOffset() {
+    return this.bank * this.bankSize;
+  }
+
+  public boolean incrementBank() {
+    return setBank(this.bank + 1);
+  }
+
+  public boolean decrementBank() {
+    if (this.bank > 0) {
+      return setBank(this.bank - 1);
+    }
+    return false;
+  }
+
+  public boolean setBank(int bank) {
+    if (bank < 0) {
+      throw new IllegalArgumentException("Channel bank may not be less than zero");
+    }
+    if (this.bank == bank) {
+      return false;
+    }
+
+    this.bank = bank;
+    if (this.isRegistered) {
+      refreshChannels();
+    }
+    listener.onBankChanged(this.bank);
+    return true;
+  }
+
+  /**
+   * Retrieve channel for a given surface index, relative to current bank.
+   */
+  public LXAbstractChannel get(int index) {
+    if (index >= 0 && index < this.channels.size()) {
+      return this.channels.get(index);
+    }
+    return null;
+  }
+
+  /**
+   * Retrieve the index of a channel relative to surface.
+   * If channel is not assigned to a surface position, null will be returned.
+   */
+  public int getIndex(LXAbstractChannel channel) {
+    return this.channels.indexOf(channel);
+  }
+
+  private final LXMixerEngine.Listener mixerEngineListener = new LXMixerEngine.Listener() {
+    @Override
+    public void channelAdded(LXMixerEngine mixer, LXAbstractChannel channel) {
+      registerChannel(channel);
+      refreshAllowedChannels();
+    }
+
+    @Override
+    public void channelMoved(LXMixerEngine mixer, LXAbstractChannel channel) {
+      refreshAllowedChannels();
+    }
+
+    @Override
+    public void channelRemoved(LXMixerEngine mixer, LXAbstractChannel channel) {
+      channelAllowance.remove(channel);
+      if (allowedChannels.remove(channel)) {
+        refreshAllowedChannels();
+      }
+    }
+  };
+
+  private boolean isRegistered = false;
+
+  public void register() {
+    if (this.isRegistered) {
+      throw new IllegalStateException("Cannot double-register MixerSurface");
+    }
+
+    this.lx.engine.mixer.addListener(this.mixerEngineListener);
+
+    for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
+      registerChannel(channel);
+    }
+    refreshAllowedChannels();
+
+    this.isRegistered = true;
+  }
+
+  public void unregister() {
+    if (!this.isRegistered) {
+      throw new IllegalStateException("Cannot unregister non-registered MixerSurface");
+    }
+
+    this.lx.engine.mixer.removeListener(this.mixerEngineListener);
+
+    this.channelAllowance.clear();
+    this.allowedChannels.clear();
+    refreshChannels();
+
+    this.isRegistered = false;
+  }
+
+  private void registerChannel(LXAbstractChannel channel) {
+    this.channelAllowance.put(channel, isChannelAllowed(channel));
+  }
+
+  private void refreshAllowedChannels() {
+    this.allowedChannels.clear();
+    for (LXAbstractChannel channel : this.lx.engine.mixer.channels) {
+      if (this.channelAllowance.get(channel)) {
+        this.allowedChannels.add(channel);
+      }
+    }
+    refreshChannels();
+  }
+
+  private void refreshChannels() {
+    final int indexOffset = getIndexOffset();
+    LXAbstractChannel channel, previous;
+    for (int i = 0; i < this.bankSize; i++) {
+      channel = i + indexOffset < this.allowedChannels.size() ? this.allowedChannels.get(i + indexOffset) : null;
+      previous = this.mutableChannels.get(i);
+      if (!LXUtils.equals(channel, previous)) {
+        this.mutableChannels.set(i, channel);
+        this.listener.onChannelChanged(i, channel, previous);
+      }
+    }
+  }
+
+  public void dispose() {
+    if (this.isRegistered) {
+      unregister();
+    }
+  }
+}

--- a/src/main/java/heronarts/lx/parameter/LXPickupParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXPickupParameter.java
@@ -1,0 +1,161 @@
+/**
+ * Copyright 2024- Justin Belcher, Mark C. Slee, Heron Arts LLC
+ *
+ * This file is part of the LX Studio software library. By using
+ * LX, you agree to the terms of the LX Studio Software License
+ * and Distribution Agreement, available at: http://lx.studio/license
+ *
+ * Please note that the LX license is not open-source. The license
+ * allows for free, non-commercial use.
+ *
+ * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
+ * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
+ * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
+ * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ *
+ * @author Mark C. Slee <mark@heronarts.com>
+ * @author Justin K. Belcher <justin@jkb.studio>
+ */
+
+package heronarts.lx.parameter;
+
+/**
+ * Utility class for mapping from a one-directional source (such as a MIDI potentiometer)
+ * to a normalized parameter.  When the target parameter is changed by a different source
+ * this class will enter an out-of-alignment state and will require
+ * a pickup (source value aligning with the parameter value) before changes are
+ * once again committed to the target.  This prevents the target value from jumping.
+ */
+public class LXPickupParameter extends LXListenableNormalizedParameter {
+
+  private LXListenableNormalizedParameter parameter;
+  private final LXParameterListener listener = this::onParameterValueChanged;
+
+  private boolean pickup = true;
+  private boolean aligned = false;
+  private boolean initialized = false;
+
+  private double sourceValue = 0;
+  private boolean internal = false;
+
+  public LXPickupParameter() {
+    this(null);
+  }
+
+  public LXPickupParameter(LXListenableNormalizedParameter target) {
+    super("Pickup", 0);
+    setParameter(target);
+  }
+
+  private boolean isAligned() {
+    // Alignment is unknown until first source value is received
+    return this.aligned && this.initialized;
+  }
+
+  public LXPickupParameter setParameter(LXListenableNormalizedParameter parameter) {
+    if (this.parameter != null) {
+      this.parameter.removeListener(this.listener);
+    }
+    this.parameter = parameter;
+    if (this.parameter != null) {
+      this.parameter.addListener(this.listener);
+      this.aligned = this.sourceValue == this.parameter.getBaseNormalized();
+    } else {
+      this.aligned = true;
+    }
+    if (!this.pickup && this.initialized) {
+      setNormalized(this.sourceValue);
+    }
+    return this;
+  }
+
+  public LXPickupParameter setPickup(boolean on) {
+    if (this.pickup != on) {
+      this.pickup = on;
+      if (!this.pickup && this.initialized) {
+        // Revering to Direct mode. Snap to known value.
+        setNormalized(this.sourceValue);
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public LXPickupParameter setNormalized(double value) {
+    if (!this.initialized) {
+      this.initialized = true;
+      this.sourceValue = value;
+      if (this.pickup) {
+        // Initial input, pickup
+        if (this.parameter != null) {
+          this.aligned = this.sourceValue == this.parameter.getBaseNormalized();
+        } else {
+          this.aligned = true;
+          bang();
+        }
+      } else {
+        // Initial input, not pickup.
+        this.aligned = true;
+        _setParameterNormalized(value);
+      }
+    } else {
+      // Not initial input
+      if (this.pickup && !this.aligned) {
+        // Out of sync with target, unless this movement achieved pickup.
+        double targetValue = getNormalized();
+        if (Double.compare(targetValue, sourceValue) != Double.compare(targetValue, value)) {
+          // Pickup achieved. We're equal or we passed the value.
+          this.aligned = true;
+        }
+      }
+      if (!this.pickup || isAligned()) {
+        _setParameterNormalized(value);
+      }
+      this.sourceValue = value;
+      if (this.parameter == null) {
+        bang();
+      }
+    }
+    return this;
+  }
+
+  private double _getParameterNormalized() {
+    if (this.parameter != null) {
+      return this.parameter.getBaseNormalized();
+    }
+    return this.sourceValue;
+  }
+
+  private void _setParameterNormalized(double value) {
+    if (this.parameter != null) {
+      this.internal = true;
+      this.parameter.setNormalized(value);
+      this.internal = false;
+    }
+  }
+
+  private void onParameterValueChanged(LXParameter parameter) {
+    if (!this.internal) {
+      // An external source changed the parameter value, likely knocking us out of sync.
+      this.aligned = this.sourceValue == this.parameter.getBaseNormalized();
+      bang();
+    }
+  }
+
+  @Override
+  public double getNormalized() {
+    return _getParameterNormalized();
+  }
+
+  @Override
+  protected double updateValue(double value) {
+    return value;
+  }
+
+  @Override
+  public void dispose() {
+    parameter.removeListener(this.listener);
+    super.dispose();
+  }
+
+}

--- a/src/main/java/heronarts/lx/utils/LXUtils.java
+++ b/src/main/java/heronarts/lx/utils/LXUtils.java
@@ -499,4 +499,17 @@ public class LXUtils {
   public static boolean isEmpty(String s) {
     return s == null || s.trim().isEmpty();
   }
+
+  /**
+   * Compare two objects either of which may be null.
+   */
+  public static boolean equals(Object obj1, Object obj2) {
+    if (obj1 == null) {
+      if (obj2 == null) {
+        return true;
+      }
+      return false;
+    }
+    return obj1.equals(obj2);
+  }
 }


### PR DESCRIPTION
Added utility class `MixerSurface` which could be used by any midi surface to add channel banking.  Trying it out first on the APCminiMk2.  Some users are interested in running two of these side-by-side to control 16 channels.  Moderately tested.

I threw in a hook for hiding channels.  Have heard users with a single controller lament how quickly the midi controller channels are used up when using groups.  Figured this was a good place to bake that in for future-proofing.

Added `LXPickupParameter` which wraps a target parameter to add a pickup mode when mapped from a one-directional midi control.  This one was a bit rushed, edits welcome.