### PR TITLE
MultiMonitor updates last value for all parameters

### DIFF
--- a/src/main/java/heronarts/lx/parameter/LXParameter.java
+++ b/src/main/java/heronarts/lx/parameter/LXParameter.java
@@ -91,12 +91,13 @@ public interface LXParameter extends LXPath {
     }
 
     public boolean changed() {
+      boolean changed = false;
       for (Monitor monitor : this.monitors) {
         if (monitor.changed()) {
-          return true;
+          changed = true;
         }
       }
-      return false;
+      return changed;
     }
   }
 


### PR DESCRIPTION
It looks like `MultiMonitor` should call `monitor.changed()` for all parameters even after a change is found, in case multiple parameters were modified in one frame.

Otherwise for example if two parameters were changed in one frame, I think `MultiMonitor.changed()` was returning `true` for two frames in a row.