### PR TITLE
Prevent washout accumulation in BlurEffect

### DIFF
--- a/src/main/java/heronarts/lx/effect/BlurEffect.java
+++ b/src/main/java/heronarts/lx/effect/BlurEffect.java
@@ -89,6 +89,10 @@ public class BlurEffect extends LXEffect {
 
   @Override
   public void run(double deltaMs, double amount) {
+    if (!isEnabled()) {
+      return;
+    }
+
     final int blurAlpha = (int) (LXColor.BLEND_ALPHA_FULL * amount * this.level.getValue());
     final int[] blurColors = this.blurBuffer.getArray();
 
@@ -100,7 +104,7 @@ public class BlurEffect extends LXEffect {
       // Apply exponential decay to the blur
       blurColors[i] = LXColor.multiply(blurColors[i], decayColor, LXColor.BLEND_ALPHA_FULL);
       // Add the new blur buffer frame
-      blurColors[i] = LXColor.add(blurColors[i], this.colors[i], LXColor.BLEND_ALPHA_FULL);
+      blurColors[i] = LXColor.lightest(blurColors[i], this.colors[i], LXColor.BLEND_ALPHA_FULL);
     }
 
     // If blur value is present, blend the blur value into the color buffer

--- a/src/main/java/heronarts/lx/effect/BlurEffect.java
+++ b/src/main/java/heronarts/lx/effect/BlurEffect.java
@@ -89,10 +89,6 @@ public class BlurEffect extends LXEffect {
 
   @Override
   public void run(double deltaMs, double amount) {
-    if (!isEnabled()) {
-      return;
-    }
-
     final int blurAlpha = (int) (LXColor.BLEND_ALPHA_FULL * amount * this.level.getValue());
     final int[] blurColors = this.blurBuffer.getArray();
 


### PR DESCRIPTION
Have felt in the past like BlurEffect too easily turned into white.  I think this was the culprit.

To reproduce:
- Set a `SolidPattern` on red with Brightness = 5%.  It is almost not visible.
- Add a `BlurEffect`: Level=100, Decay=1s, Factor=50%.
- Enable the `BlurEffect`.  The blurBuffer rapidly accumulates to full red, 100% brightness.

I'm thinking the intention is for new colors to have an "overwrite" effect e.g. max(blurBuffer, new) but not an additive effect.  If the pattern jumped around between colors this was easily creating white.  Seems better now in local testing.

Added a `return` when disabled to save the math overhead, since the blurBuffer is reset when re-enabled.