### PR TITLE
Increment BoundedParameter relative to base

### DIFF
--- a/src/main/java/heronarts/lx/parameter/BoundedParameter.java
+++ b/src/main/java/heronarts/lx/parameter/BoundedParameter.java
@@ -357,7 +357,7 @@ public class BoundedParameter extends LXListenableNormalizedParameter {
   }
 
   public BoundedParameter incrementValue(double amount, boolean wrap) {
-    double newValue = getValue() + amount;
+    double newValue = getBaseValue() + amount;
     if (wrap) {
       if (newValue > this.range.max) {
         newValue = this.range.min + ((newValue - this.range.max) % this.range.range);


### PR DESCRIPTION
Calls to increment a BoundedParameter should modify the value relative to base value, not modulated value!

This was apparent if you called `parameter.incrementValue(0)` on a modulated parameter every frame... the modulated value became the new base value.