### PR TITLE
Dispose mixer surface field from APC surfaces

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APC40.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40.java
@@ -1225,6 +1225,7 @@ public class APC40 extends LXMidiSurface implements LXMidiSurface.Bidirectional 
       fader.dispose();
     }
     this.deviceListener.dispose();
+    this.mixerSurface.dispose();
     super.dispose();
   }
 

--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1973,6 +1973,7 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
       fader.dispose();
     }
     this.deviceListener.dispose();
+    this.mixerSurface.dispose();
     super.dispose();
   }
 


### PR DESCRIPTION
Showed up as a stranded listener on numscenes.