### PR TITLE
LXMidiEngine: check for 'class' field in surface before loading the field from LXP

### DIFF
--- a/src/main/java/heronarts/lx/midi/LXMidiEngine.java
+++ b/src/main/java/heronarts/lx/midi/LXMidiEngine.java
@@ -1316,7 +1316,7 @@ public class LXMidiEngine extends LXComponent implements LXOscComponent {
             if (surface != null) {
               surface.load(lx, surfaceObj);
               surface.enabled.setValue(true);
-            } else {
+            } else if (surfaceObj.has(KEY_CLASS)) {
               // We have a MIDI surface remembered from a previous load, but it was not auto-instantiated
               // meaning most likely that the hardware is not connected anymore. Or that the device uses
               // a non-standard name. Do a custom instantiation in this case.


### PR DESCRIPTION
When upgrading TE's LX dependency, we noticed some LXP files from ~April 2024 stopped loading, with the following stack trace: 

```
LX 2025/02/15 12:29:43] Exception in openProject: Cannot invoke "com.google.gson.JsonElement.getAsString()" because the return value of "com.google.gson.JsonObject.get(String)" is null
java.lang.NullPointerException: Cannot invoke "com.google.gson.JsonElement.getAsString()" because the return value of "com.google.gson.JsonObject.get(String)" is null
	at heronarts.lx.midi.LXMidiEngine.lambda$load$9(LXMidiEngine.java:1323)
	at heronarts.lx.midi.LXMidiEngine.whenReady(LXMidiEngine.java:750)
	at heronarts.lx.midi.LXMidiEngine.load(LXMidiEngine.java:1285)
	at heronarts.lx.LXComponent.load(LXComponent.java:1471)
	at heronarts.lx.LXEngine.load(LXEngine.java:1465)
	at heronarts.lx.LX.openProject(LX.java:1117)
	at heronarts.lx.LXPreferences.loadInitialProject(LXPreferences.java:325)
	at heronarts.lx.studio.TEApp.lambda$main$2(TEApp.java:1063)
	at heronarts.lx.LXEngine._run(LXEngine.java:1160)
	at heronarts.lx.LXEngine.run(LXEngine.java:1060)
	at heronarts.lx.LXEngine.access$1400(LXEngine.java:66)
	at heronarts.lx.LXEngine$ExecutorService.runLoop(LXEngine.java:725)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
	at java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
	at java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
	at java.base/java.lang.Thread.run(Thread.java:1583)
```

We dug in a bit more, and found that the stack trace originated here: 

![image](https://github.com/user-attachments/assets/96466d22-87b9-4dbb-a418-8da267cc4dbe)


We found that some newer LXP files (post-August 2024) didn't encounter this error, but the older ones did. I grepped through the LXP's before and after, and noticed that the older ones didn't have the `class` key in their `midi.surface` mappings - on the left is an LXP that boots up fine, and on the right hand side is the one that hits an exception and won't finish loading the LXP:

![image](https://github.com/user-attachments/assets/65f36d81-a982-4d29-b402-e43d4a36e8a5)

Specifically, if you wanted to reproduce the error:

1. Check out this branch of TE: `libs1.0.1.te.3` from this PR: https://github.com/titanicsend/LXStudio-TE/pull/595 
2. Start Chromatik, then open `Projects/CoachellaMaster.lxp` (which is the showfile missing `class` on its midi surfaces).

We don't mind archiving our older LXP files, so this issue isn't a blocker for us - just wanted to share a little fix to make some checks when loading the LXP, so that attempting to load older serializations of MIDI specs doesnt crash Chromatik / prevent it from loading successfully.
