### PR TITLE
Notify focusedChannel listeners on unregister

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/FocusedChannel.java
+++ b/src/main/java/heronarts/lx/midi/surface/FocusedChannel.java
@@ -57,12 +57,12 @@ public class FocusedChannel {
       this.focusedChannel = (LXChannel) channel;
       this.focusedChannel.controlSurfaceSemaphore.increment();
     }
+    this.listener.onChannelFocused(channel);
   }
 
   private void onChannelFocused(LXParameter p) {
     LXBus bus = this.isAux ? this.lx.engine.mixer.getFocusedChannelAux() : this.lx.engine.mixer.getFocusedChannel();
     setFocusedChannel(bus);
-    this.listener.onChannelFocused(bus);
   }
 
   public void register() {


### PR DESCRIPTION
Moved the listener notification to the `setFocusedChannel()` method, so that it also fires when `unregister()` sets the channel to `null`.  This way a listener can know when to unregister a channel, including when surface is disabled and there is no longer a focused channel.
