### PR TITLE
reproduce LXF parsing bug: "true&&true"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,6 +69,12 @@
 		    <artifactId>slf4j-simple</artifactId>
 		    <version>2.0.16</version>
 		</dependency>
+		<dependency>
+		    <groupId>org.junit.jupiter</groupId>
+		    <artifactId>junit-jupiter</artifactId>
+		    <version>5.10.1</version>
+		    <scope>test</scope>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/heronarts/lx/structure/JsonFixture.java
+++ b/src/main/java/heronarts/lx/structure/JsonFixture.java
@@ -1044,7 +1044,7 @@ public class JsonFixture extends LXFixture {
   // Super-trivial hacked up implementation of *very* basic math expressions, which has now
   // got some functions tacked on. If this slippery slope keeps sliding will need to get a
   // real expression parsing + evaluation library involved at some point...
-  private float _evaluateNumericExpression(String expression) {
+  static float _evaluateNumericExpression(String expression) {
     if (_evaluateExpression(expression) instanceof ExpressionResult.Numeric numeric) {
       return numeric.number;
     }
@@ -1065,14 +1065,14 @@ public class JsonFixture extends LXFixture {
     }
   }
 
-  private boolean _evaluateBooleanExpression(String expression) {
+  static boolean _evaluateBooleanExpression(String expression) {
     if (_evaluateExpression(expression) instanceof ExpressionResult.Boolean bool) {
       return bool.bool;
     }
     throw new IllegalArgumentException("Expected expression to be boolean: " + expression);
   }
 
-  private static abstract class ExpressionResult {
+  static abstract class ExpressionResult {
 
     private static class Numeric extends ExpressionResult {
       private final float number;
@@ -1113,7 +1113,7 @@ public class JsonFixture extends LXFixture {
     { "^" }
   };
 
-  private int _getOperatorIndex(String expression, char[] chars, String operator) {
+  static int _getOperatorIndex(String expression, char[] chars, String operator) {
     if ("-".equals(operator)) {
       for (int index = chars.length - 1; index > 0; --index) {
         // Skip over the tricky unary minus operator! If preceded by another operator,
@@ -1136,7 +1136,7 @@ public class JsonFixture extends LXFixture {
    * @param expression Portion of expression to evaluate
    * @return ExpressionResult, which may be boolean or numeric
    */
-  private ExpressionResult _evaluateExpression(String expression) {
+  static ExpressionResult _evaluateExpression(String expression) {
     char[] chars = expression.toCharArray();
 
     // Parentheses pass

--- a/src/test/java/heronarts/lx/structure/JsonFixtureTest.java
+++ b/src/test/java/heronarts/lx/structure/JsonFixtureTest.java
@@ -1,0 +1,19 @@
+package heronarts.lx.structure;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class JsonFixtureTest {
+    // @BeforeEach
+    // void setUp() {
+    //     evaluator = new StringExpressionEvaluator();
+    // }
+
+    // // Helper methods for cleaner test code
+    // private float evaluateNumeric(String expression) {
+    //     return evaluator.evaluateNumeric(expression);
+    // }
+}

--- a/src/test/java/heronarts/lx/structure/JsonFixtureTest.java
+++ b/src/test/java/heronarts/lx/structure/JsonFixtureTest.java
@@ -2,18 +2,19 @@ package heronarts.lx.structure;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 public class JsonFixtureTest {
-    // @BeforeEach
-    // void setUp() {
-    //     evaluator = new StringExpressionEvaluator();
-    // }
+    @Test
+    void testSimpleEvaluateBooleanExpression() {
+        assertEquals(true, JsonFixture._evaluateBooleanExpression("true"));
+        // Using ".toString()" as least invasive way to access the contents of ExpressionResult
+        assertEquals("true", JsonFixture._evaluateExpression("true").toString());
+    }
 
-    // // Helper methods for cleaner test code
-    // private float evaluateNumeric(String expression) {
-    //     return evaluator.evaluateNumeric(expression);
-    // }
+    @Test
+    void testEvaluateBooleanExpressionWithAndOperator() {
+        assertEquals(true, JsonFixture._evaluateBooleanExpression("true&&true"));
+        assertEquals("true", JsonFixture._evaluateExpression("true&&true").toString());
+    }
 }


### PR DESCRIPTION
Reproducing a small evaluator bug: `true&&true` (bug is also present for `true && true`). It gives this stack trace:

```
java.lang.IllegalArgumentException: Cannot evaluate empty expression:
	at heronarts.lx.structure.JsonFixture._evaluateExpression(JsonFixture.java:1285)
	at heronarts.lx.structure.JsonFixture._evaluateBooleanExpression(JsonFixture.java:1069)
	at heronarts.lx.structure.JsonFixture._evaluateExpression(JsonFixture.java:1199)
```

I'm not sure how you feel about JUnit, but this was the easiest way for me to share a directly reproducible version of the bug without loading up the full Chromatik app and sharing a fixture file.

I'm also not sure how you feel about structuring code for testability - I noticed that none of the evaluate methods used any object state, so I made them `static` (and package-protected rather than `private`) just to make it easier to isolate and test that one piece of functionality.