### PR TITLE
ExpressionTest: add coverage for common cases

### DIFF
--- a/.github/workflows/spotless.yml
+++ b/.github/workflows/spotless.yml
@@ -1,0 +1,28 @@
+##name: Verify Tests Pass
+on:
+  pull_request:
+    branches:
+      - main
+      - dev
+      # TODO(look): remove these (after verifying)
+      - add-expression-tests
+  push:
+    branches:
+      - main
+      - dev
+      - add-expression-tests
+jobs:
+  spotless:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # Cache maven dependencies across job runs, to speed things up:
+      # https://docs.github.com/en/actions/how-tos/use-cases-and-examples/building-and-testing/building-and-testing-java-with-maven#caching-dependencies
+      - name: Set up JDK 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: 21
+          cache: 'maven'
+      - name: Verify Tests Pass
+        run: mvn --batch-mode --update-snapshots verify

--- a/.github/workflows/verify.yml
+++ b/.github/workflows/verify.yml
@@ -4,13 +4,10 @@ on:
     branches:
       - main
       - dev
-      # TODO(look): remove these (after verifying)
-      - add-expression-tests
   push:
     branches:
       - main
       - dev
-      - add-expression-tests
 jobs:
   spotless:
     runs-on: ubuntu-latest

--- a/src/test/java/heronarts/lx/structure/ExpressionTest.java
+++ b/src/test/java/heronarts/lx/structure/ExpressionTest.java
@@ -21,7 +21,7 @@ import org.junit.jupiter.api.Test;
 import static heronarts.lx.structure.Expression.*;
 import static org.junit.jupiter.api.Assertions.*;
 
-public class JsonFixtureTest {
+public class ExpressionTest {
 
     /**
      * Testing more complex expressions, similar to an expression that might show up in an actual LXF

--- a/src/test/java/heronarts/lx/structure/JsonFixtureTest.java
+++ b/src/test/java/heronarts/lx/structure/JsonFixtureTest.java
@@ -1,60 +1,206 @@
 /**
  * Copyright 2025- Mark C. Slee, Heron Arts LLC
  *
- * This file is part of the LX Studio software library. By using
- * LX, you agree to the terms of the LX Studio Software License
- * and Distribution Agreement, available at: http://lx.studio/license
+ * <p>This file is part of the LX Studio software library. By using LX, you agree to the terms of
+ * the LX Studio Software License and Distribution Agreement, available at: http://lx.studio/license
  *
- * Please note that the LX license is not open-source. The license
- * allows for free, non-commercial use.
+ * <p>Please note that the LX license is not open-source. The license allows for free,
+ * non-commercial use.
  *
- * HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR
- * OTHERWISE, AND SPECIFICALLY DISCLAIMS ANY WARRANTY OF
- * MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR
- * PURPOSE, WITH RESPECT TO THE SOFTWARE.
+ * <p>HERON ARTS MAKES NO WARRANTY, EXPRESS, IMPLIED, STATUTORY, OR OTHERWISE, AND SPECIFICALLY
+ * DISCLAIMS ANY WARRANTY OF MERCHANTABILITY, NON-INFRINGEMENT, OR FITNESS FOR A PARTICULAR PURPOSE,
+ * WITH RESPECT TO THE SOFTWARE.
  *
  * @author Andrew M. Look <andrew.m.look@gmail.com>
  * @author Mark C. Slee <mark@heronarts.com>
  */
-
 package heronarts.lx.structure;
-
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.Test;
 
+import static heronarts.lx.structure.Expression.*;
+import static org.junit.jupiter.api.Assertions.*;
+
 public class JsonFixtureTest {
-  @Test
-  void testSimpleEvaluateBooleanExpression() {
-    assertEquals(true, Expression.evaluateBoolean("true"));
-    assertEquals(Expression.Result.Boolean.TRUE, Expression.evaluate("true"));
-  }
 
-  @Test
-  void testEvaluateBooleanExpressionWithAndOperator() {
-    assertEquals(true, Expression.evaluateBoolean("true&&true"));
-    assertEquals(Expression.Result.Boolean.TRUE, Expression.evaluate("true&&true"));
-  }
+    /**
+     * Testing more complex expressions, similar to an expression that might show up in an actual LXF
+     * file, for example: ($offset+(($row-1)/2))*$pointSpacing
+     */
+    @Test
+    void testLXFLikeExpressions() {
+        //
+        // We'll simulate with actual numbers since variables aren't available in this context
 
-  @Test
-  void testEvaluateUnaryMinus() {
-    assertEquals(-1f, Expression.evaluateNumeric("-(-(-1))"));
-  }
+        // Simulate: offset=0, row=2, pointSpacing=1.9685039
+        // (0+((2-1)/2))*1.9685039 = (0+(1/2))*1.9685039 = 0.5*1.9685039 = 0.98425195
+        assertEquals(0.98425195f, evaluateNumeric("(0+((2-1)/2))*1.9685039"), 0.0001f);
 
-  @Test
-  void testEvaluateFunctionCalls() {
-    assertEquals(0f, Expression.evaluateNumeric("sin(180)"));
-    assertEquals(1f, Expression.evaluateNumeric("sin(90)"));
-    assertEquals(0f, Expression.evaluateNumeric("cos(90)"));
-    assertEquals(-1f, Expression.evaluateNumeric("cos(180)"));
-    assertEquals(1f, Expression.evaluateNumeric("tan(45)"));
-    assertEquals(-1f, Expression.evaluateNumeric("tan(-45)"));
-    assertEquals(1f, Expression.evaluateNumeric("pow(2, 0)"));
-    assertEquals(32f, Expression.evaluateNumeric("pow(2, 5)"));
-    assertEquals(90f, Expression.evaluateNumeric("atan2(1, 0)"));
-    assertEquals(135f, Expression.evaluateNumeric("atan2(1, -1)"));
-    assertEquals(180f, Expression.evaluateNumeric("atan2(0, -1)"));
-    assertEquals(-45f, Expression.evaluateNumeric("atan2(-1, 1)"));
-    assertEquals(315f, Expression.evaluateNumeric("atan2p( ((2-3)) , (sin(90)))"));
-  }
+        // Simulate: offset=1, row=3, pointSpacing=1.9685039
+        // (1+((3-1)/2))*1.9685039 = (1+1)*1.9685039 = 2*1.9685039 = 3.9370078
+        assertEquals(3.9370078f, evaluateNumeric("(1+((3-1)/2))*1.9685039"), 0.0001f);
+
+        // Test expression like: ($row-1)*$rowSpacing
+        // Simulate: row=2, rowSpacing=1.7047743848
+        // (2-1)*1.7047743848 = 1*1.7047743848 = 1.7047743848
+        assertEquals(1.7047743848f, evaluateNumeric("(2-1)*1.7047743848"), 0.0001f);
+
+        // Test expression like: ($offset+(($row-1)/2)-0.5)*$pointSpacing
+        // Simulate: offset=0, row=2, pointSpacing=1.9685039
+        // (0+((2-1)/2)-0.5)*1.9685039 = (0+0.5-0.5)*1.9685039 = 0*1.9685039 = 0
+        assertEquals(0.0f, evaluateNumeric("(0+((2-1)/2)-0.5)*1.9685039"), 0.0001f);
+
+        // Test ternary expression like: $flipBacking ? -2 : 2
+        assertEquals(-2.0f, evaluateNumeric("true?-2:2"));
+        assertEquals(2.0f, evaluateNumeric("false?-2:2"));
+    }
+
+    @Test
+    void testLiterals() {
+        assertEquals(42.0f, evaluateNumeric("42"));
+        assertEquals(3.14f, evaluateNumeric("3.14"));
+        assertEquals(-5.0f, evaluateNumeric("-5"));
+        assertEquals(0.0f, evaluateNumeric("0"));
+        assertEquals(0f, ((Expression.Result.Numeric) evaluate("0")).getNumber());
+        assertTrue(evaluateBoolean("true"));
+        assertFalse(evaluateBoolean("false"));
+        assertEquals(Expression.Result.Boolean.TRUE, evaluate("true"));
+    }
+
+    @Test
+    void testWhitespaceHandling() {
+        assertEquals(7.0f, evaluateNumeric("3 + 4"));
+        assertEquals(12.0f, evaluateNumeric("  3  *  4  "));
+    }
+
+    @Test
+    void testBasicArithmetic() {
+        assertEquals(7.0f, evaluateNumeric("3+4"));
+        assertEquals(-1.0f, evaluateNumeric("3-4"));
+        assertEquals(12.0f, evaluateNumeric("3*4"));
+        assertEquals(0.75f, evaluateNumeric("3/4"));
+        assertEquals(1.0f, evaluateNumeric("3%2"));
+        assertEquals(9.0f, evaluateNumeric("3^2"));
+    }
+
+    @Test
+    void testOperatorPrecedence() {
+        assertEquals(14.0f, evaluateNumeric("2+3*4"));
+        assertEquals(20.0f, evaluateNumeric("(2+3)*4"));
+        assertEquals(11.0f, evaluateNumeric("3+2^3"));
+        assertEquals(125.0f, evaluateNumeric("(3+2)^3"));
+    }
+
+    @Test
+    void testNestedParentheses() {
+        assertEquals(42.0f, evaluateNumeric("((((42))))"));
+        assertEquals(22.0f, evaluateNumeric("2*((3+4)*2-3)"));
+        assertEquals(46.0f, evaluateNumeric("2*(3+(4*5))"));
+    }
+
+    @Test
+    void testComparisonOperations() {
+        assertTrue(evaluateBoolean("5>3"));
+        assertFalse(evaluateBoolean("3>5"));
+        assertTrue(evaluateBoolean("5>=5"));
+        assertTrue(evaluateBoolean("3<5"));
+        assertFalse(evaluateBoolean("5<3"));
+        assertTrue(evaluateBoolean("3<=3"));
+        assertTrue(evaluateBoolean("5==5"));
+        assertFalse(evaluateBoolean("5==3"));
+        assertTrue(evaluateBoolean("5!=3"));
+        assertFalse(evaluateBoolean("5!=5"));
+    }
+
+    @Test
+    void testLogicalOperations() {
+        assertTrue(evaluateBoolean("true&&true"));
+        assertFalse(evaluateBoolean("true&&false"));
+        assertTrue(evaluateBoolean("true||false"));
+        assertFalse(evaluateBoolean("false||false"));
+
+        // Test both forms of logical operators
+        assertTrue(evaluateBoolean("true&true"));
+        assertTrue(evaluateBoolean("true|false"));
+    }
+
+    @Test
+    void testUnaryOperators() {
+        assertEquals(-5.0f, evaluateNumeric("-5"));
+        assertEquals(5.0f, evaluateNumeric("--5"));
+        assertEquals(-5.0f, evaluateNumeric("---5"));
+
+        assertFalse(evaluateBoolean("!true"));
+        assertTrue(evaluateBoolean("!false"));
+        assertTrue(evaluateBoolean("!!true"));
+    }
+
+    @Test
+    void testEvaluateUnaryMinus() {
+        assertEquals(-1f, evaluateNumeric("-(-(-1))"));
+    }
+
+    @Test
+    void testArithmeticWithUnary() {
+        assertEquals(0.0f, evaluateNumeric("4+-4"));
+    }
+
+    @Test
+    void testEvaluateFunctionCalls() {
+        assertEquals(0f, evaluateNumeric("sin(180)"));
+        assertEquals(1f, evaluateNumeric("sin(90)"));
+        assertEquals(0f, evaluateNumeric("cos(90)"));
+        assertEquals(-1f, evaluateNumeric("cos(180)"));
+        assertEquals(1f, evaluateNumeric("tan(45)"));
+        assertEquals(-1f, evaluateNumeric("tan(-45)"));
+        assertEquals(1f, evaluateNumeric("pow(2, 0)"));
+        assertEquals(32f, evaluateNumeric("pow(2, 5)"));
+        assertEquals(90f, evaluateNumeric("atan2(1, 0)"));
+        assertEquals(135f, evaluateNumeric("atan2(1, -1)"));
+        assertEquals(180f, evaluateNumeric("atan2(0, -1)"));
+        assertEquals(-45f, evaluateNumeric("atan2(-1, 1)"));
+        assertEquals(315f, evaluateNumeric("atan2p( ((2-3)) , (sin(90)))"));
+        assertEquals(0f, evaluateNumeric("sin(000.0)"), 0.0001f);
+        assertEquals(1f, evaluateNumeric("cos(0.000)"), 0.0001f);
+        assertEquals(5f, evaluateNumeric("abs(-5)"));
+        assertEquals(3f, evaluateNumeric("sqrt(9.0)"));
+        assertEquals(2f, evaluateNumeric("floor(2.7)"));
+        assertEquals(3f, evaluateNumeric("round(2.7)"));
+        // Note(look): this doesn't work yet, unclear if it should even be supported
+        //    assertEquals(3f, evaluateNumeric("ceil(+2.3)"));
+    }
+
+    @Test
+    void testTernaryConditional() {
+        assertEquals(10.0f, evaluateNumeric("true?10:20"));
+        assertEquals(20.0f, evaluateNumeric("false?10:20"));
+        assertEquals(5.0f, evaluateNumeric("3>2?5:7"));
+        assertEquals(7.0f, evaluateNumeric("2>3?5:7"));
+
+        // Nested ternary
+        assertEquals(1.0f, evaluateNumeric("true?true?1:2:3"));
+        assertEquals(2.0f, evaluateNumeric("true?false?1:2:3"));
+        assertEquals(3.0f, evaluateNumeric("false?true?1:2:3"));
+
+        // Nested ternary (with parentheses)
+        assertEquals(3.0f, evaluateNumeric("false?(true?1:2):3"));
+        assertEquals(3.0f, evaluateNumeric(" false ?  ( true ?  1 : 2  ) :  3 "));
+    }
+
+    @Test
+    void testEvaluateErrorCases() {
+        // Test empty expression
+        assertThrows(IllegalArgumentException.class, () -> evaluate(""));
+
+        // Test mismatched parentheses
+        assertThrows(IllegalArgumentException.class, () -> evaluate("(2+3"));
+        assertThrows(IllegalArgumentException.class, () -> evaluate("2+3)"));
+
+        // Test mismatched ternary conditional
+        assertThrows(IllegalArgumentException.class, () -> evaluate("true?5"));
+        assertThrows(IllegalArgumentException.class, () -> evaluate("5:3"));
+
+        // Test invalid number format
+        assertThrows(NumberFormatException.class, () -> evaluate("abc"));
+    }
 }


### PR DESCRIPTION
Adding some test coverage to the ExpressionTest (and renaming it from JsonFixtureTest, now that the class has been extracted). I'm generally not a huge fan of code coverage tools, or rules like "stay above X% coverage" - but I find that for complex logic like we're dealing with here, it can be handy to "run unit tests with coverage" in my IDE and then get a clear picture of which logical branches are untested. Again, not about getting to 100% but it can help pinpoint bugs.

I added a bunch of happy-path tests because I wanted to just have some reasonable coverage of the common cases we expect `Expression` to support - and now the coverage report is actually somewhat informative of areas to keep an eye on, for example:

![Screen Shot 2025-07-04 at 5 40 07 PM](https://github.com/user-attachments/assets/46304132-ae04-4f9b-8229-c5351b07fafd)

Also, in case it's useful, I added a little github action to automate [running the tests](https://docs.github.com/en/actions/how-tos/use-cases-and-examples/building-and-testing/building-and-testing-java-with-maven#building-and-testing-your-code) on any PR vs. dev or main branches (configurable), and/or run them on any commits made to those branches outside of a PR (just b/c it can be helpful to see which commit broke tests retroactively). In github you can configure whether you want to block PR's if tests aren't passing/etc, but I'd imagine that's not a huge concern at the moment.

The action won't run on this PR in the heronarts repo unless you decide to merge it (for security reasons), but here's an example run where it verified the tests on the commit in my fork: https://github.com/andrewlook/LX/actions/runs/16081382037/job/45386559842#step:4:447