### PR TITLE
Setup JMH Benchmarks for LXBlend implementation ideas

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,6 +1,6 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>com.heronarts</groupId>
@@ -40,12 +40,15 @@
 
 		<gson.version>2.13.1</gson.version>
 		<coremidi4j.version>1.6</coremidi4j.version>
+		<jmh.version>1.37</jmh.version>
 
 		<maven-assembly-plugin.version>3.6.0</maven-assembly-plugin.version>
 		<exec-maven-plugin.version>3.1.1</exec-maven-plugin.version>
 		<maven-javadoc-plugin.version>3.6.3</maven-javadoc-plugin.version>
 		<maven-source-plugin.version>3.3.0</maven-source-plugin.version>
 		<maven-compiler-plugin.version>3.12.1</maven-compiler-plugin.version>
+		<maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>
+		<jmh-plugin.version>0.2.2</jmh-plugin.version>
 	</properties>
 
 	<dependencies>
@@ -60,20 +63,32 @@
 			<version>${coremidi4j.version}</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.jmdns</groupId>
-		    <artifactId>jmdns</artifactId>
-		    <version>3.6.1</version>
+			<groupId>org.jmdns</groupId>
+			<artifactId>jmdns</artifactId>
+			<version>3.6.1</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.slf4j</groupId>
-		    <artifactId>slf4j-simple</artifactId>
-		    <version>2.0.16</version>
+			<groupId>org.slf4j</groupId>
+			<artifactId>slf4j-simple</artifactId>
+			<version>2.0.16</version>
 		</dependency>
 		<dependency>
-		    <groupId>org.junit.jupiter</groupId>
-		    <artifactId>junit-jupiter</artifactId>
-		    <version>5.10.1</version>
-		    <scope>test</scope>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>5.10.1</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-core</artifactId>
+			<version>${jmh.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.openjdk.jmh</groupId>
+			<artifactId>jmh-generator-annprocess</artifactId>
+			<version>${jmh.version}</version>
+			<scope>test</scope>
 		</dependency>
 	</dependencies>
 
@@ -158,13 +173,32 @@
 					</execution>
 				</executions>
 			</plugin>
+
+			<!-- mvn jmh:benchmark -Drf=json -Drff="benchmarks.json" -->
+			<plugin>
+				<groupId>pw.krejci</groupId>
+				<artifactId>jmh-maven-plugin</artifactId>
+				<version>${jmh-plugin.version}</version>
+			</plugin>
+
+			<!-- make sure JUnit ignores benchmarks, since JUnit has conflicting dependencies with JMH -->
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>${maven-surefire-plugin.version}</version>
+				<configuration>
+					<excludes>
+						<exclude>**/*benchmark*</exclude>
+					</excludes>
+				</configuration>
+			</plugin>
 		</plugins>
-    </build>
-    <profiles>
-        <profile>
-            <id>deploy</id>
-           	<build>
-	            <plugins>
+	</build>
+	<profiles>
+		<profile>
+			<id>deploy</id>
+			<build>
+				<plugins>
 					<plugin>
 						<groupId>org.sonatype.central</groupId>
 						<artifactId>central-publishing-maven-plugin</artifactId>
@@ -188,8 +222,8 @@
 							</execution>
 						</executions>
 					</plugin>
-	            </plugins>
-            </build>
-        </profile>
-    </profiles>
+				</plugins>
+			</build>
+		</profile>
+	</profiles>
 </project>

--- a/src/test/java/heronarts/lx/benchmarks/AddBlend0005000Points.java
+++ b/src/test/java/heronarts/lx/benchmarks/AddBlend0005000Points.java
@@ -1,0 +1,37 @@
+package heronarts.lx.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+
+
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 1)
+@Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
+public class AddBlend0005000Points extends BlendingHarness {
+  static final int NUM_CHANNELS = 16;
+  static final int NUM_POINTS_PER_CHANNEL = 5_000;
+
+  @Setup(Level.Trial)
+  public void setupWholeTrial() {
+    setupTrialBase(NUM_CHANNELS, NUM_POINTS_PER_CHANNEL);
+  }
+
+  @Benchmark
+  public void measureLXBlend() {
+    blendToTest.blend(dst, src, alpha, actual, model);
+  }
+
+  
+}

--- a/src/test/java/heronarts/lx/benchmarks/AddBlend0100000Points.java
+++ b/src/test/java/heronarts/lx/benchmarks/AddBlend0100000Points.java
@@ -1,0 +1,34 @@
+package heronarts.lx.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 1)
+@Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
+public class AddBlend0100000Points extends BlendingHarness {
+  static final int NUM_CHANNELS = 16;
+  static final int NUM_POINTS_PER_CHANNEL = 100_000;
+
+  @Setup(Level.Trial)
+  public void setupWholeTrial() {
+    setupTrialBase(NUM_CHANNELS, NUM_POINTS_PER_CHANNEL);
+  }
+
+  @Benchmark
+  public void measureLXBlend() {
+    blendToTest.blend(dst, src, alpha, actual, model);
+  }
+}

--- a/src/test/java/heronarts/lx/benchmarks/AddBlend2000000Points.java
+++ b/src/test/java/heronarts/lx/benchmarks/AddBlend2000000Points.java
@@ -1,0 +1,34 @@
+package heronarts.lx.benchmarks;
+
+import java.util.concurrent.TimeUnit;
+
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Timeout;
+
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 1)
+@Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
+public class AddBlend2000000Points extends BlendingHarness {
+  static final int NUM_CHANNELS = 16;
+  static final int NUM_POINTS_PER_CHANNEL = 2_000_000;
+
+  @Setup(Level.Trial)
+  public void setupWholeTrial() {
+    setupTrialBase(NUM_CHANNELS, NUM_POINTS_PER_CHANNEL);
+  }
+
+  @Benchmark
+  public void measureLXBlend() {
+    blendToTest.blend(dst, src, alpha, actual, model);
+  }
+}

--- a/src/test/java/heronarts/lx/benchmarks/BenchmarkSuite.java
+++ b/src/test/java/heronarts/lx/benchmarks/BenchmarkSuite.java
@@ -1,0 +1,33 @@
+package heronarts.lx.benchmarks;
+
+import java.util.List;
+
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+public class BenchmarkSuite {
+  static final List<Class<?>> benchmarkTests = List.of(
+      AddBlend0005000Points.class,
+      AddBlend0100000Points.class,
+      AddBlend2000000Points.class
+  );
+
+  public static void main(String[] args) throws RunnerException {
+    for (Class<?> clazz : benchmarkTests) {
+      String simpleName = clazz.getSimpleName();
+      System.out.println("\n\n----------------\nPreparing to run: " + simpleName + "\n----------------\n\n");
+      String fname = "target/benchmark_" + simpleName + ".json";
+      Options opt = new OptionsBuilder()
+          .include(simpleName)
+          .result(fname)
+          .resultFormat(ResultFormatType.JSON)
+          .build();
+      new Runner(opt).run();
+      System.out.println("Results saved to " + fname);
+      System.out.println("Upload to https://jmh.morethan.io/ for HTML visualization");
+    }
+  }
+}

--- a/src/test/java/heronarts/lx/benchmarks/BlendingHarness.java
+++ b/src/test/java/heronarts/lx/benchmarks/BlendingHarness.java
@@ -1,0 +1,171 @@
+package heronarts.lx.benchmarks;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.TimeUnit;
+
+import heronarts.lx.LX;
+import heronarts.lx.blend.AddBlend;
+import heronarts.lx.blend.LXBlend;
+import heronarts.lx.color.LXColor;
+import heronarts.lx.model.LXModel;
+import heronarts.lx.model.LXPoint;
+import org.openjdk.jmh.annotations.BenchmarkMode;
+import org.openjdk.jmh.annotations.Fork;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.annotations.OutputTimeUnit;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.Setup;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Timeout;
+import org.openjdk.jmh.results.format.ResultFormatType;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.Options;
+import org.openjdk.jmh.runner.options.OptionsBuilder;
+
+/**
+ * Hierarchy:
+ *
+ *    Trial
+ *    ├── Iteration 1
+ *      │   ├── Invocation 1
+ *      │   ├── Invocation 2
+ *      │   └── Invocation N
+ *    ├── Iteration 2
+ *      │   ├── Invocation 1
+ *      │   └── ...
+ *      └── Iteration M
+ *
+ * The rough plan here:
+ * - For each "trial", create a bunch of color buffers, so we're not worrying about memory allocation during the test.
+ * - Also precompute their correct answers using LX baseline impl, so that for the alternate implementations we can
+ *   verify correctness (maybe this belongs here, or maybe a similar harness could be used for randomized testing).
+ *
+ * - For each "iteration":
+ *   - For each "invocation": ("numTests")
+ *     - Select a different pair of dest/source arrays, blend them into actual[].
+ */
+@BenchmarkMode(Mode.All)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 1, warmups = 1)
+@Timeout(time = 10, timeUnit = TimeUnit.SECONDS)
+public class BlendingHarness {
+  public LX lx;
+  public LXModel model;
+
+  // Per-trial state
+  public int numChannels;
+  public int numPointsPerChannel;
+  public int[][] destinations;
+  public int[][] sources;
+  public int[][] actualOutputs;
+  public int[][] expectedOutputs;
+
+  // Current limitations: only testing one blend at a time, with one alpha value, scoped to whole model (not views).
+  // TODO: consider separating this logic out - e.g. to make an array of blends to test, or array of BlendTargets, etc
+  public double alpha;
+  public LXBlend blendToTest;
+
+  // Per-invocation state
+  int index;
+  int[] dst;
+  int[] src;
+  int[] expected;
+  int[] actual;
+
+  public void setupTrialBase(int numChannels, int numPointsPerChannel) {
+    this.numChannels = numChannels;
+    this.numPointsPerChannel = numPointsPerChannel;
+
+    model = fakeModelWithNumPoints(numPointsPerChannel);
+    lx = new LX(model);
+
+    destinations = generateColorArrays(numChannels, numPointsPerChannel);
+    sources = generateColorArrays(numChannels, numPointsPerChannel);
+    actualOutputs = new int[numChannels][numPointsPerChannel];
+    // zero out the arrays we'll use to store our outputs
+    for (int i = 0; i < numChannels; i++) {
+      Arrays.fill(actualOutputs[i], LXColor.BLACK);
+    }
+
+    blendToTest = new AddBlend(lx);
+    alpha = 0.9;
+    expectedOutputs = blendResult(blendToTest, destinations, sources, alpha, model);
+  }
+
+  @Setup(Level.Invocation)
+  public void setupInvocationBase() {
+    dst = destinations[index];
+    src = sources[index];
+    expected = expectedOutputs[index];
+    actual = actualOutputs[index];
+  }
+
+  @TearDown(Level.Invocation)
+  public void verifyInvocationBase() {
+    assert Arrays.equals(expected, actual);
+    this.index = (this.index + 1) % this.numChannels;
+  }
+
+  public void baseRunner(Class<?> clazz) throws RunnerException {
+    String simpleName = clazz.getSimpleName();
+    System.out.println("\n\n----------------\nPreparing to run: " + simpleName + "\n----------------\n\n");
+    String fname = "target/benchmark_" + simpleName + ".json";
+    Options opt = new OptionsBuilder()
+        .include(simpleName)
+        .result(fname)
+        .resultFormat(ResultFormatType.JSON)
+        .build();
+    new Runner(opt).run();
+    System.out.println("Results saved to " + fname);
+    System.out.println("Upload to https://jmh.morethan.io/ for HTML visualization");
+  }
+
+  public static int[][] generateColorArrays(int numTests, int numPointsPerChannel) {
+    Random rand = new Random();
+    int[][] result = new int[numTests][numPointsPerChannel];
+    for (int i = 0; i < numTests; i++) {
+      for (int j = 0; j < numPointsPerChannel; j++) {
+        int r = rand.nextInt(256);
+        int g = rand.nextInt(256);
+        int b = rand.nextInt(256);
+        int a = rand.nextInt(256);
+        result[i][j] = LXColor.rgba(r, g, b, a);
+      }
+    }
+    return result;
+  }
+
+  public static LXModel fakeModelWithNumPoints(int numPointsPerChannel) {
+    List<LXPoint> points = new ArrayList<>();
+    for (int j = 0; j < numPointsPerChannel; j++) {
+      points.add(new LXPoint((float) j, (float) j + 1));
+    }
+    return new LXModel(points);
+  }
+
+  public static int[][] blendResult(LXBlend blend, int[][] left, int[][] right, double alpha, LXModel model) {
+    int numTests = left.length;
+    int numPointsPerChannel = left[0].length;
+    if (right.length != numTests) {
+      throw new RuntimeException("mismatched num tests");
+    } else if (right[0].length != numPointsPerChannel) {
+      throw new RuntimeException("mismatches num points per test");
+    }
+    int[][] blendResult = new int[numTests][numPointsPerChannel];
+    for (int i = 0; i < numTests; i++) {
+      int[] out = blendResult[i];
+      int[] dst = left[i];
+      int[] src = right[i];
+
+      blend.blend(dst, src, alpha, out, model);
+    }
+    return blendResult;
+  }
+}


### PR DESCRIPTION
Setting up a micro-benchmarking framework, in order to run some experiments with blending implementations.

The rough idea here was to isolate `LXBlend`, and generate a bunch of `int[] src, dst, out` to test blending. During setup, I allocate all the memory (and precompute the correct output values using the current blend implementation - this is only a no-op verification for now, but the idea is that if we have an alternate implementation, that would serve as a kind of randomized testing assertion).

Simplifications for now:
- only testing `AddBlend` to start
- using the same alpha every time
- using the same `LXModel` scope every time (as opposed to blending with `start, num`, or with different model views)

My thinking here is that at a coarse level, we just want to understand a rough order of magnitude of performance across whatever implementations we try. I don't have a great mental model for cache lines/etc, but I figured that at least rotating the arrays that we're blending ensures they aren't kept hot in L1/L2 cache. It might be more realistic (albeit more complicated to set up) to actually benchmark the full `LXMixerEngine`, which would allow testing the concurrent chunking implementation there (or maybe that could be abstracted below the level of "blend", somehow).

So my main goal here was to test out the `AddBlend` with varying numbers of points, selected somewhat arbitrarily (but going up to ~2M, where @jkbelcher and I started to hit problems and needed to go the GPU/compute shader route)
- 5000
- 100000
- 2000000

<details>
<summary>Initial Results</summary>

> Note: these aren't very useful until we have something to compare them to, but figured I'd share the initial result anyways. The benchmark took about 30 mins to run - there might be some tuning to do on the iteration timeout. I don't have a good sense yet for how long it "needs" to be.

```
Benchmark                                       Mode      Cnt   Score    Error   Units
AddBlend100000Points.measureLXBlend               ss            0.331            ms/op
AddBlend100000Points.measureLXBlend             avgt        5   0.259 ±  0.030   ms/op
AddBlend100000Points.measureLXBlend            thrpt        5   3.975 ±  0.065  ops/ms
AddBlend100000Points.measureLXBlend           sample   200301   0.250 ±  0.001   ms/op
AddBlend100000Points.measureLXBlend:p0.00     sample            0.227            ms/op
AddBlend100000Points.measureLXBlend:p0.50     sample            0.246            ms/op
AddBlend100000Points.measureLXBlend:p0.90     sample            0.259            ms/op
AddBlend100000Points.measureLXBlend:p0.95     sample            0.273            ms/op
AddBlend100000Points.measureLXBlend:p0.99     sample            0.306            ms/op
AddBlend100000Points.measureLXBlend:p0.999    sample            0.435            ms/op
AddBlend100000Points.measureLXBlend:p0.9999   sample            0.829            ms/op
AddBlend100000Points.measureLXBlend:p1.00     sample            1.673            ms/op
```

```
Benchmark                                       Mode      Cnt   Score    Error   Units
AddBlend2000000Points.measureLXBlend              ss            7.262            ms/op
AddBlend2000000Points.measureLXBlend            avgt        5   7.147 ±  0.061   ms/op
AddBlend2000000Points.measureLXBlend           thrpt        5   0.141 ±  0.002  ops/ms
AddBlend2000000Points.measureLXBlend          sample     7166   6.980 ±  0.008   ms/op
AddBlend2000000Points.measureLXBlend:p0.00    sample            6.341            ms/op
AddBlend2000000Points.measureLXBlend:p0.50    sample            6.980            ms/op
AddBlend2000000Points.measureLXBlend:p0.90    sample            7.225            ms/op
AddBlend2000000Points.measureLXBlend:p0.95    sample            7.315            ms/op
AddBlend2000000Points.measureLXBlend:p0.99    sample            7.572            ms/op
AddBlend2000000Points.measureLXBlend:p0.999   sample            8.274            ms/op
AddBlend2000000Points.measureLXBlend:p0.9999  sample            9.519            ms/op
AddBlend2000000Points.measureLXBlend:p1.00    sample            9.519            ms/op
```

```
Benchmark                                       Mode      Cnt   Score    Error   Units
AddBlend5000Points.measureLXBlend                 ss            0.065            ms/op
AddBlend5000Points.measureLXBlend               avgt        5   0.011 ±  0.001   ms/op
AddBlend5000Points.measureLXBlend              thrpt        5  87.007 ±  0.810  ops/ms
AddBlend5000Points.measureLXBlend             sample  1053260   0.012 ±  0.001   ms/op
AddBlend5000Points.measureLXBlend:p0.00       sample            0.010            ms/op
AddBlend5000Points.measureLXBlend:p0.50       sample            0.011            ms/op
AddBlend5000Points.measureLXBlend:p0.90       sample            0.014            ms/op
AddBlend5000Points.measureLXBlend:p0.95       sample            0.014            ms/op
AddBlend5000Points.measureLXBlend:p0.99       sample            0.017            ms/op
AddBlend5000Points.measureLXBlend:p0.999      sample            0.021            ms/op
AddBlend5000Points.measureLXBlend:p0.9999     sample            0.035            ms/op
AddBlend5000Points.measureLXBlend:p1.00       sample            0.288            ms/op
```

</details>

About the library: I remembered Google's "Caliper" from a long time ago, but their github refers users to the JVM team's benchmarking tool JMH. It's fairly easy to work with, and the [sample code](https://github.com/openjdk/jmh/blob/master/jmh-samples/src/main/java/org/openjdk/jmh/samples/) is pretty informative. There's a [maven plugin](https://github.com/metlos/jmh-maven-plugin) and IDE plugins (I used the [IntelliJ one](https://github.com/artyushov/idea-jmh-plugin?tab=readme-ov-file) and was up and running right away).

Some small gotchas: I wanted to keep JMH libraries out of prod dependencies, so they're scoped as "test" and the benchmark code is in `src/test`. JUnit chokes on the JMH files, so I used a maven workaround to have maven-surefire-plugin ignore the contents of `src/test/heronarts/lx/benchmarks`. The alternative is to do add a new source root like `src/jmh`, but that felt overly invasive.