### PR TITLE
Loop aux cue channel even if auto-muted

### DIFF
--- a/src/main/java/heronarts/lx/mixer/LXAbstractChannel.java
+++ b/src/main/java/heronarts/lx/mixer/LXAbstractChannel.java
@@ -295,7 +295,7 @@ public abstract class LXAbstractChannel extends LXBus implements LXComponent.Ren
 
   private boolean isAnimating() {
     // Cue is active? We must loop to preview ourselves
-    if (this.cueActive.isOn()) {
+    if (this.cueActive.isOn() || this.auxActive.isOn()) {
       return true;
     }
     // We're not active? Then we're disabled for sure


### PR DESCRIPTION
When a channel is aux-cued it should get looped for the preview.