### PR TITLE
LXOscConnection.filter: allow comma-delimited list

### DIFF
--- a/src/main/java/heronarts/lx/osc/LXOscConnection.java
+++ b/src/main/java/heronarts/lx/osc/LXOscConnection.java
@@ -68,6 +68,8 @@ public abstract class LXOscConnection extends LXComponent {
     new StringParameter("Filter", "/lx")
     .setDescription("Filter OSC messages on matching prefix");
 
+  private String[] parsedFilters = null;
+
   private int _defaultInputPort() {
     int max = lx.engine.osc.receivePort.getValuei();
     for (LXOscConnection connection : lx.engine.osc.inputs) {
@@ -131,8 +133,13 @@ public abstract class LXOscConnection extends LXComponent {
     addParameter("active", this.active);
   }
 
-  protected String getFilter() {
-    return this.hasFilter.isOn() ? this.filter.getString() : null;
+  protected String[] getFilters() {
+    return this.hasFilter.isOn() ? this.parsedFilters : null;
+  }
+
+  protected void parseFilterString(String filter) {
+    // TODO: remove whitespace and/or empty entries? e.g. "/lx/palette/hue , ,/lx/tempo"
+    this.parsedFilters = filter.split(",");
   }
 
   /**
@@ -171,6 +178,8 @@ public abstract class LXOscConnection extends LXComponent {
         } else {
           stopReceiver(IOState.STOPPED);
         }
+      } else if (p == this.filter) {
+        this.parseFilterString(this.filter.getString());
       }
     }
 
@@ -259,6 +268,8 @@ public abstract class LXOscConnection extends LXComponent {
           // can easily toggle back on
           this.state.setValue(IOState.STOPPED);
         }
+      } else if (p == this.filter) {
+        this.parseFilterString(this.filter.getString());
       }
     }
 

--- a/src/main/java/heronarts/lx/osc/LXOscEngine.java
+++ b/src/main/java/heronarts/lx/osc/LXOscEngine.java
@@ -515,9 +515,23 @@ public class LXOscEngine extends LXComponent {
       return this.active.isOn() && (this.state.getEnum() == IOState.BOUND);
     }
 
+    /**
+     * Whether or not this OSC address should be "filtered out" from the stream we're transmitting.
+     *
+     * @param oscAddress
+     * @return true if filters is null/empty, or if address matches one of the filters
+     */
     private boolean isAddressFiltered(String oscAddress) {
-      final String prefixFilter = (this.connection != null) ? this.connection.getFilter() : null;
-      return (prefixFilter != null) && !OscMessage.hasPrefix(oscAddress, prefixFilter);
+      final String[] prefixFilters = (this.connection != null) ? this.connection.getFilters() : null;
+      if (prefixFilters == null || prefixFilters.length == 0) {
+        return false;
+      }
+      for (String prefix : prefixFilters) {
+        if (OscMessage.hasPrefix(oscAddress, prefix)) {
+          return false;
+        }
+      }
+      return true;
     }
 
     @Override


### PR DESCRIPTION
Adding support for multiple filter prefixes. For example, `/lx/tempo,/lx/palette/swatch/color/`.

Only thing I was curious to get your take on: I'm not sure how hot the inner loops of `LXOscEngine` are, and whether looping an array comparison is something that we'd want to avoid for performance reasons. It seems like this would only affect people who are using filters at all, but wouldn't impact OSC outputs that aren't using filters.