### PR TITLE
fix: EnumParameter setValue for enums with bodies

### DIFF
--- a/src/main/java/heronarts/lx/parameter/EnumParameter.java
+++ b/src/main/java/heronarts/lx/parameter/EnumParameter.java
@@ -31,10 +31,9 @@ public class EnumParameter<T extends Enum<T>> extends ObjectParameter<T> impleme
 
   public final Class<T> enumClass;
 
-  @SuppressWarnings("unchecked")
   public EnumParameter(String label, T t) {
     super(label, valuesFor(t), t);
-    this.enumClass = (Class<T>) t.getClass();
+    this.enumClass = t.getDeclaringClass();
   }
 
   public EnumParameter<T> setEnum(String enumName) {


### PR DESCRIPTION
I've been seeing an error on project open after a recent refactor to our color theory system:

```
[LX 2025/08/02 16:34:16] Failed to load EnumParameter at path paletteStrategy by name: "SPLIT_COMPLEMENTARY"
java.lang.IllegalArgumentException: titanicsend.color.PaletteStrategy$1 is not an enum class
	at java.base/java.lang.Class.enumConstantDirectory(Class.java:4040)
	at java.base/java.lang.Enum.valueOf(Enum.java:287)
	at heronarts.lx.parameter.EnumParameter.setEnum(EnumParameter.java:41)
	at heronarts.lx.parameter.EnumParameter.setEnum(EnumParameter.java:21)
	at heronarts.lx.LXSerializable$Utils.loadParameter(LXSerializable.java:174)
	at heronarts.lx.LXComponent.loadParameters(LXComponent.java:1486)
	at heronarts.lx.LXComponent.load(LXComponent.java:1529)
	at heronarts.lx.LXComponent.load(LXComponent.java:1537)
```

The [code in question](https://github.com/titanicsend/LXStudio-TE/blob/main/te-app/src/main/java/titanicsend/color/PaletteStrategy.java#L6-L49) uses enums with anonymous class-style bodies, for example:

```java
/** Mechanisms for deriving a second and third complementary color given a starting color */
public enum PaletteStrategy {
  ANALOGOUS("Analogous") {
    public int getColor2(float h, float s, float b) {
      return LXColor.hsb(h + 30, s, b);
    }

    public int getColor3(float h, float s, float b) {
      return LXColor.hsb(h - 30, s, b);
    }
  },

  // ...
}
```

Nothing looked suspicious in the LXP:

```java
      "paletteManagerA": {
        "id": 162,
        "class": "titanicsend.color.ColorPaletteManager",
        "internal": {
          "modulationColor": 0,
          "modulationControlsExpanded": true,
          "modulationsExpanded": true
        },
        "parameters": {
          "label": "Color Palette Manager",
          "isExpanded": true,
          "paletteStrategy": 1,
          "paletteStrategy/name": "GOLDEN_RATIO_CONJUGATE",
          "pushSwatch": false,
          "pinSwatch": false
        },
        "children": {}
      },
```

When I dropped a debugger inside `EnumParameter.setEnum()`, I noticed that all the cases where it's used inside the LX codebase either have enums with just the constants, or the optional String label (but no class bodies). I also noticed that `enumClass` in all of those cases was exactly the classname of the enum, while in the problematic case I saw `titanicsend.color.PaletteStrategy$1`.

So it seems that if the enum has a class body, the compiler treats it as a subclass of the outer enum, but we'd like to set `enumClass` to the outer enum.

After looking around a bit, it seems that conceptually what we want would work like this:

```java
private static <T extends Enum<T>> Class<T> getEnumClass(T enumConstant) {
    Class<?> clazz = enumConstant.getClass();

    // If this enum constant has an anonymous class body, its class will be
    // a subclass of the actual enum class. We need to get the superclass.
    if (clazz.isAnonymousClass() || clazz.isMemberClass()) {
        // For enum constants with bodies, the superclass is the actual enum class
        clazz = clazz.getSuperclass();
    }

    @SuppressWarnings("unchecked")
    Class<T> enumClass = (Class<T>) clazz;
    return enumClass;
}
```

But there's actually a built-in method `getDeclaringClass` that does exactly this: https://docs.oracle.com/javase/8/docs/api/java/lang/Class.html#getDeclaringClass--