### PR TITLE
fix: LXDeviceComponent.getModelView NPE

### DIFF
--- a/src/main/java/heronarts/lx/LXDeviceComponent.java
+++ b/src/main/java/heronarts/lx/LXDeviceComponent.java
@@ -18,9 +18,22 @@
 
 package heronarts.lx;
 
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
+
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
+
 import heronarts.lx.midi.LXMidiListener;
 import heronarts.lx.midi.LXShortMessage;
 import heronarts.lx.midi.MidiFilterParameter;
@@ -41,17 +54,6 @@ import heronarts.lx.parameter.MutableParameter;
 import heronarts.lx.pattern.LXPattern;
 import heronarts.lx.structure.view.LXViewDefinition;
 import heronarts.lx.structure.view.LXViewEngine;
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * A component which may have its own scoped user-level modulators. The concrete subclasses

--- a/src/main/java/heronarts/lx/LXDeviceComponent.java
+++ b/src/main/java/heronarts/lx/LXDeviceComponent.java
@@ -18,22 +18,9 @@
 
 package heronarts.lx;
 
-import java.io.IOException;
-import java.io.PrintWriter;
-import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.concurrent.CopyOnWriteArraySet;
-
 import com.google.gson.JsonArray;
 import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
-
 import heronarts.lx.midi.LXMidiListener;
 import heronarts.lx.midi.LXShortMessage;
 import heronarts.lx.midi.MidiFilterParameter;
@@ -54,6 +41,17 @@ import heronarts.lx.parameter.MutableParameter;
 import heronarts.lx.pattern.LXPattern;
 import heronarts.lx.structure.view.LXViewDefinition;
 import heronarts.lx.structure.view.LXViewEngine;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CopyOnWriteArraySet;
 
 /**
  * A component which may have its own scoped user-level modulators. The concrete subclasses
@@ -205,7 +203,11 @@ public abstract class LXDeviceComponent extends LXLayeredComponent implements LX
     if (view != null) {
       return view.getModelView();
     }
-    return switch (getParent()) {
+    LXComponent parent = getParent();
+    if (parent == null) {
+      return getModel();
+    }
+    return switch (parent) {
       case LXMasterBus master -> lx.model;
       case LXAbstractChannel bus -> bus.getModelView();
       case LXPattern pattern -> pattern.getModelView();


### PR DESCRIPTION
We [noticed](https://github.com/titanicsend/LXStudio-TE/pull/688#issuecomment-3146950180) that `getParent()` is sometimes null when this method is called, and the switch statement throws an exception if called with a null value. Adding a check first and returning the same value as the default case.