### PR TITLE
Always save TriggerParameter as false

### DIFF
--- a/src/main/java/heronarts/lx/LXSerializable.java
+++ b/src/main/java/heronarts/lx/LXSerializable.java
@@ -35,6 +35,7 @@ import heronarts.lx.parameter.FunctionalParameter;
 import heronarts.lx.parameter.IEnumParameter;
 import heronarts.lx.parameter.LXParameter;
 import heronarts.lx.parameter.StringParameter;
+import heronarts.lx.parameter.TriggerParameter;
 
 /**
  * Interface for any object that may be stored and loaded from a serialized file using
@@ -107,6 +108,8 @@ public interface LXSerializable {
     public static void saveParameter(LXParameter parameter, JsonObject obj, String path) {
       if (parameter instanceof StringParameter) {
         obj.addProperty(path, ((StringParameter) parameter).getString());
+      } else if (parameter instanceof TriggerParameter) {
+        obj.addProperty(path, false);
       } else if (parameter instanceof BooleanParameter) {
         obj.addProperty(path, ((BooleanParameter) parameter).isOn());
       } else if (parameter instanceof IEnumParameter<?> enumParameter) {


### PR DESCRIPTION
I think there's a code path where a `TriggerParameter` could fire off a serialization of its parent, and the `TriggerParameter` value would get stored as true.  This would cause it to fire whenever the object was loaded which is undesired.