### PR TITLE
Fix null checks on OscEngine and Tempo

### DIFF
--- a/src/main/java/heronarts/lx/Tempo.java
+++ b/src/main/java/heronarts/lx/Tempo.java
@@ -588,7 +588,7 @@ public class Tempo extends LXModulatorComponent implements LXOscComponent, LXTri
   }
 
   public Tempo addListener(Listener listener) {
-    Objects.requireNonNull("May not add null Tempo.Listener");
+    Objects.requireNonNull(listener,"May not add null Tempo.Listener");
     if (this.listeners.contains(listener)) {
       throw new IllegalStateException("Cannot add duplicate Tempo.Listener: " + listener);
     }

--- a/src/main/java/heronarts/lx/osc/LXOscEngine.java
+++ b/src/main/java/heronarts/lx/osc/LXOscEngine.java
@@ -276,7 +276,7 @@ public class LXOscEngine extends LXComponent {
   }
 
   public LXOscEngine addIOListener(IOListener listener) {
-    Objects.requireNonNull("May not add null IOListener");
+    Objects.requireNonNull(listener, "May not add null IOListener");
     if (this.ioListeners.contains(listener)) {
       throw new IllegalStateException(
         "Cannot add duplicate LXOscEngine.IOListener: "
@@ -297,7 +297,7 @@ public class LXOscEngine extends LXComponent {
   }
 
   public LXOscEngine addListener(LXOscListener listener) {
-    Objects.requireNonNull("May not add null LXOscListener");
+    Objects.requireNonNull(listener, "May not add null LXOscListener");
     if (this.listeners.contains(listener)) {
       throw new IllegalStateException(
         "Cannot add duplicate LXOscEngine.LXOscListener: "
@@ -692,7 +692,7 @@ public class LXOscEngine extends LXComponent {
     }
 
     public Receiver addListener(LXOscListener listener) {
-      Objects.requireNonNull("May not add null LXOscListener");
+      Objects.requireNonNull(listener,"May not add null LXOscListener");
       if (this.listeners.contains(listener)) {
         throw new IllegalStateException("Cannot add duplicate LXOscEngine.Receiver.LXOscListener: " + listener);
       }


### PR DESCRIPTION
Caught a few null checks that were checking the string and not the listener object.