### PR TITLE
Add accessor to shift state for child classes

### DIFF
--- a/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
+++ b/src/main/java/heronarts/lx/midi/surface/APC40Mk2.java
@@ -1554,6 +1554,10 @@ public class APC40Mk2 extends LXMidiSurface implements LXMidiSurface.Bidirection
     return isAuxActive() ? this.lx.engine.mixer.focusedChannel : this.lx.engine.mixer.focusedChannelAux;
   }
 
+  protected boolean isShift() {
+    return this.shiftOn;
+  }
+
   private class CueState {
     private int cueDown = 0;
     private boolean singleCueStartedOn = false;


### PR DESCRIPTION
I'd like to read the state of the shift button from a child class without intercepting the midi notes.